### PR TITLE
Adding ability to use a cell's content for link generation

### DIFF
--- a/src/partials/editor.options.html
+++ b/src/partials/editor.options.html
@@ -160,14 +160,28 @@
 					<label class="gf-form-label">Column</label>
 					<input type="text" class="gf-form-input" label="column" placeholder="Metrics" ng-model="style.column">
 				</div>
+				<div class="gf-form" ng-if="style.type === 'string'">
+				  <label class="gf-form-label width-7">Split cell by</label>
+				  <input type="text" placeholder="Name or regex" class="gf-form-input width-20" ng-model="style.splitPattern" bs-tooltip="'Specify regex using /my.*regex/ syntax'"
+						 ng-model-onblur ng-blur="editor.render()" data-placement="right">
+				  <info-popover mode="right-absolute">
+					<p>Specify an regular expression</p>
+					<span>
+					  Use a regular expression to split a cell's content:
+					  <br>
+					  <em>$__pattern_n</em> refers to Nth sub-string after splitting the cell's content. Sub-string indexes are started from 0. For instance,
+					  <em>$__pattern_0</em> refers to the first sub-string of a cell's content.
+					</span>
+				  </info-popover>
+				</div>
 				<div class="gf-form gf-form--grow">
 					<div class="gf-form-label gf-form-label--grow"></div>
 				</div>
 				<div class="gf-form">
 				  <label class="gf-form-label">
-				    <a class="pointer" ng-click="ctrl.removeColumnStyle(style)">
-				      <i class="fa fa-trash"></i>
-				    </a>
+					<a class="pointer" ng-click="ctrl.removeColumnStyle(style)">
+					  <i class="fa fa-trash"></i>
+					</a>
 				  </label>
 				</div>
 			</div>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -57,11 +57,22 @@ export class DatatableRenderer {
     if (_.isArray(v)) {
       v = v.join(', ');
     }
+
+    var cellTemplate          = style.url;
+    var cellTemplateVariables = {};
+    if (typeof style.splitPattern === 'undefined' || style.splitPattern === '') {
+      style.splitPattern = '/ /';
+    }
+
+    var regex  = kbn.stringToJsRegex(String(style.splitPattern));
+    var values = v.split(regex);
+    values.map((val, i) => cellTemplate = cellTemplate.replace(`$__pattern_${i}`, val));
+
     if (style && style.sanitize) {
       return this.sanitize(v);
     }
-    else if (style && style.link && style.url && column.text === style.column) {
-      return '<a href="' + style.url.replace('{}', v) + '" target="_blank">' + v + '</a>';
+    else if (style && style.link && cellTemplate && column.text === style.column) {
+      return '<a href="' + cellTemplate.replace('{}', v) + '" target="_blank">' + v + '</a>';
     }
     else if (style && style.link) {
       return '<a href="' + v + '" target="_blank">' + v + '</a>';


### PR DESCRIPTION
This change adds an input box to the Link section of the Column Styles
tab in the table panel plugin. This 'Split cell by' input box takes a
regular expression that will be used to split a cell's content. Once
the cell's content has been split the sub-strings will be available
for URL generation using the $__pattern_n variables starting from
0. The default behavior splits the cell's content by spaces.