### PR TITLE
[Fix] Column Sorting not working

### DIFF
--- a/src/ctrl.ts
+++ b/src/ctrl.ts
@@ -634,16 +634,12 @@ export class DatatablePanelCtrl extends MetricsPanelCtrl {
         // allow numbers and column names
         const columnData = this.panel.sortByColumns[i].columnData;
         let columnNumber = 0;
-        try {
-          columnNumber = parseInt(columnData, 10);
-        } catch (e) {
-          // check if empty
-          if (columnData === '') {
-            columnNumber = 0;
-          }
+        columnNumber = parseInt(columnData, 10);
+        if (Number.isNaN(columnNumber)) {
+          columnNumber = 0;
           // find the matching column index
-          for (let j = 0; j < this.panel.columns.length; j++) {
-            if (this.panel.columns[j].text === columnData) {
+          for (let j = 0; j < this.table.columns.length; j++) {
+            if (this.table.columns[j].text === columnData) {
               columnNumber = j;
               break;
             }

--- a/src/partials/editor.options.html
+++ b/src/partials/editor.options.html
@@ -93,7 +93,7 @@
 					<label class="gf-form-label width-10">Sorting Rule</label>
 					<input type="text"
 					  class="gf-form-input width-20"
-						ng-model="column.name"
+						ng-model="column.columnData"
 						bs-typeahead="ctrl.getColumnNames"
 						ng-change="ctrl.columnSortChanged()"
 						data-min-length="0"

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -620,7 +620,7 @@ export class DatatableRenderer {
       scrollCollapse: false,
       scrollX: true,
       scrollY: panelHeight,
-      stateSave: true,
+      stateSave: false,
       dom: 'Bfrtip',
       buttons: ['copy', 'excel', 'csv', 'pdf', 'print'],
       select: selectSettings,


### PR DESCRIPTION
Fix Column Sorting function.

* When `stateSave` options set `true` would always get previous state. It made any sort change not work.
* Column Sorting data is `columnData`, not `name`.
* [`parseInt`](https://developer.mozilla.org/zh-TW/docs/Web/JavaScript/Reference/Global_Objects/parseInt) does not throw exception. Use `NaN` to check if need mapping `columnNumber`.
* `columns` data is in `this.table` not `this.panel`.