### PR TITLE
fix #117: derive type from data in 1st row when column.type is missing

### DIFF
--- a/src/DatatableRenderer.ts
+++ b/src/DatatableRenderer.ts
@@ -441,6 +441,13 @@ export class DatatableRenderer {
       if (columnType === 'string') {
         columnClassName = 'dt-right';
       }
+
+      // if we did not get a type prop from grafana at all, 
+      // check at least if it's a number to have DT sort properly
+      if (!columnType && this.table.rows[0] && (typeof this.table.rows[0][i]) === 'number' ) {
+        columnType = 'num';
+      }
+
       // NOTE: the width below is a "hint" and will be overridden as needed, this lets most tables show timestamps
       // with full width
       /* jshint loopfunc: true */


### PR DESCRIPTION
I'm trying to migrate a legacy dashboard application that uses datatables to Grafana, and stumbled upon #117. Don't know much about Grafana's plugin architecture, what I see is just that `dataList` in `onDataReceived` does not have `type` properties in the columns, at least in my sample queries on SQL Server 2016.
Maybe this workaround is useful for others - until the plugin is lifted to the new architecture or the real root cause is identified.