### PR TITLE
Drop filter/sort on raw cell values

### DIFF
--- a/src/DatatableRenderer.ts
+++ b/src/DatatableRenderer.ts
@@ -457,11 +457,8 @@ export class DatatableRenderer {
             return null;
           }
           const idx = meta.col;
-          // sort/filter/type use raw
-          let returnValue = row[idx].raw;
-          if (type === 'display') {
-            returnValue = row[idx].display;
-          }
+          // use display type for return
+          let returnValue = row[idx].display;
           return returnValue;
         },
         render: function(data: any, type: any, val: any, meta: any) {
@@ -472,11 +469,8 @@ export class DatatableRenderer {
           if (type === 'type') {
             return val[idx];
           }
-          // sort/filter use raw
-          let returnValue = val[idx].raw;
-          if (type === 'display') {
-            returnValue = val[idx].display;
-          }
+          // use display type for return
+          let returnValue = val[idx].display;
           return returnValue;
         },
         createdCell: (td: any, cellData: any, rowData: any, row: any, col: any) => {


### PR DESCRIPTION
Rendering a table from multiple datasources on a merge without equivalent fields leads to popup on each refresh:
<img width="448" alt="Screen Shot 2021-08-17 at 9 50 45 AM" src="https://user-images.githubusercontent.com/25035114/129776159-2dc93b5c-e6de-4f50-aca6-4bae8233edc1.png">

This PR drops the reference to the raw data, silencing the popup, and relies only on the display value. Perhaps there is specific sorting behavior desired for undefined values, but as far as I've tested, the empty string sorting behaves equivalently. 