### PR TITLE
chore(gitignore): ignore local .claude/ session-state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ provisioning-private/
 importable/
 test-results/
 TODO.md
+.claude/


### PR DESCRIPTION
## Summary

- Adds `.claude/` to `.gitignore` so per-project Claude Code session artifacts (`scheduled_tasks.lock`, `settings.local.json`) stop showing in `git status`.
- No functional change to the repo or CI.

## Test plan

- [x] `git status` is clean on a fresh checkout after the change (local verification)