### PR TITLE
feat(options): configurable text alignment for string columns (closes #282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,20 +10,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Configurable text alignment for string columns** (closes #282). String
   columns were previously hard-coded to right-align in `getColumnClassName`
   with no user-visible knob. Two complementary controls:
-  - New panel-level **Right Align Text** toggle (`alignStringsToRightEnabled`,
-    default `true`). Disabling it lets string columns inherit the DataTables
-    default (left-aligned).
-  - New per-column **Cell Alignment** Select on each column style
-    (`ColumnStyleItemType.align`, values `default | left | center | right`).
-    A non-`default` value paints an inline `text-align` on each matching cell
-    that overrides the panel-level class. Applies to any `activeStyle`
-    (metric / string / date), so the same knob covers all column types.
-  - Defaults preserve today's right-aligned behavior; the option migrates
-    to `true` and new column styles seed `align='default'`.
-  - Covered by new unit cases (migration defaults, Cell Alignment emit,
-    addItem seed) and an e2e spec
-    (`tests/phase3-panel/text-alignment.spec.ts`) that loads a provisioned
-    dashboard and asserts an inline `text-align: left` style is applied.
+  - Panel-level **Right Align Text** toggle (`alignStringsToRightEnabled`,
+    default `true`). Disabling it lets string columns inherit the
+    DataTables default (left-aligned).
+  - Per-column **Cell Alignment** Select on each column style
+    (`ColumnStyleItemType.align`, values `default | left | center |
+    right`). A non-`default` value paints an inline `text-align` on each
+    matching cell that overrides the panel-level class. Applies to any
+    `activeStyle` (metric / string / date), so the same knob covers all
+    column types.
 
 ### Scaffolding & Configuration
 
@@ -144,6 +139,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   simplified to spread-with-overrides. Covered by `ColumnStylesEditor.test.tsx`,
   which locks in the `isOpen`-by-`ID` behavior across remove and guards against
   `onChange` firing on mount.
+- Move `ColumnAlignment` / `ColumnAlignmentOptions` into `src/types.ts`
+  alongside the other global option enums (`ColumnStyleColoring`,
+  `DatatablePagingType`, `AggregationType`).
+- Collapse the two adjacent positional booleans on `getColumnClassName`,
+  `BuildColumnDefs`, and `ConvertDataFrameToDataTableFormat` into a single
+  `AlignmentFlags = { numbers, strings }` struct, so a transposition at a
+  call site would now be a type error.
 
 ### Tooling
 
@@ -178,6 +180,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the same pass: Unreleased categorised into subsections and older releases
   split into Added / Changed / Fixed / Removed groups, with the legacy pre-
   0.0.7 table converted to per-version sections.
+- Patch alignment defaults into existing React-saved panels.
+  `DatatablePanelMigrationHandler`'s non-Angular branch returned
+  `panel.options` unchanged, so the first load of a panel saved before
+  #282 would read `alignStringsToRightEnabled=undefined` and render the
+  options editor's Switch in an "off" state while the panel itself was
+  still right-aligning via the class. A new `applyOptionDefaults` helper
+  seeds `alignStringsToRightEnabled=true` when missing and stamps
+  `align='default'` on every column style that lacks it. The helper is
+  the documented hook for any future field added to `DatatableOptions`
+  or `ColumnStyleItemType`.
+- Defense-in-depth: `createdCell` now whitelists `aStyle.align` against
+  `ColumnAlignmentOptions` before piping it into jQuery's
+  `.css('text-align', ...)`. The value comes from panel JSON and is
+  typed but not runtime-validated, so a hand-crafted dashboard could
+  previously feed an arbitrary string into the DOM style API. Browsers
+  reject invalid `text-align` values so there's no known exploit; this
+  hardens the boundary anyway.
 
 ### Testing
 
@@ -194,6 +213,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   suffix. DOM-level protection for the `setThresholds` fix — a future
   regression that drops `colorMode` or the unit formatter would fail this
   spec rather than silently paint default-colored cells.
+- Unit cases for the #282 alignment feature: `migrations.test.ts` pins
+  both the Angular-path `migrateDefaults` seeds and the React-path
+  `applyOptionDefaults` patching (missing flag, explicit `false`
+  preserved, missing `align` stamped, end-to-end handler flow).
+  `ColumnStyleItem.test.tsx` asserts the Cell Alignment Select emits
+  the chosen value; `ColumnStylesEditor.test.tsx` asserts `addItem`
+  stamps `align='default'` on new trackers.
+- Add `tests/phase3-panel/text-alignment.spec.ts` plus
+  `provisioning/dashboards/dashboards/Datatable-TextAlignment.json`.
+  Loads a panel whose column style sets `align='left'` and asserts at
+  least one cell carries an inline `text-align: left` — DOM-level
+  protection for the per-column override path.
 
 ## [2.0.2] - 2025-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `BuildColumnDefs`, and `ConvertDataFrameToDataTableFormat` into a single
   `AlignmentFlags = { numbers, strings }` struct, so a transposition at a
   call site would now be a type error.
+- Memoize the `AlignmentFlags` literal in `DataTablePanel.tsx` with
+  `useMemo` keyed on the two panel booleans. The three `useEffect` dep
+  arrays now depend on the memoized reference instead of the two raw
+  primitives — same re-run cadence per toggle, but the stable-identity
+  invariant is enforced by reference equality instead of by convention,
+  so a future contributor can't accidentally cause an infinite loop by
+  dropping an inline object into a dep array.
 
 ### Tooling
 
@@ -217,14 +224,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   both the Angular-path `migrateDefaults` seeds and the React-path
   `applyOptionDefaults` patching (missing flag, explicit `false`
   preserved, missing `align` stamped, end-to-end handler flow).
-  `ColumnStyleItem.test.tsx` asserts the Cell Alignment Select emits
-  the chosen value; `ColumnStylesEditor.test.tsx` asserts `addItem`
-  stamps `align='default'` on new trackers.
+  `ColumnStyleItem.test.tsx` parameterizes the Cell Alignment Select
+  emit test across LEFT / CENTER / RIGHT and pins the DEFAULT fallback
+  when `style.align` is undefined. `ColumnStylesEditor.test.tsx`
+  asserts `addItem` stamps `align='default'` on new trackers and that
+  `createDuplicate` carries `align` through the spread-with-overrides
+  copy (same bug class as the `colorMode` regression).
+- Add `src/data/dataHelpers.test.ts` — parameterized branch table for
+  `getColumnClassName` across every `columnType` × alignment-flag
+  combination (number / string / time / date / boolean × on / off).
+  Core of the #282 contract (strings can be un-right-aligned) is now a
+  hard assertion, not an implementation detail.
 - Add `tests/phase3-panel/text-alignment.spec.ts` plus
   `provisioning/dashboards/dashboards/Datatable-TextAlignment.json`.
   Loads a panel whose column style sets `align='left'` and asserts at
   least one cell carries an inline `text-align: left` — DOM-level
   protection for the per-column override path.
+- Add `tests/phase3-panel/text-alignment-panel-level.spec.ts` plus
+  `provisioning/dashboards/dashboards/Datatable-TextAlignmentPanelLevel.json`.
+  Uses a csv_content target (`Name`, `Value`) with
+  `alignStringsToRightEnabled=false` and
+  `alignNumbersToRightEnabled=true` — asserts the Name column cells
+  do NOT carry `dt-right` while the Value column cells still do. This
+  is the end-to-end proof of issue #282 itself: the panel-level
+  switch disables class-level right-alignment on string columns.
 
 ## [2.0.2] - 2025-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable text alignment for string columns** (closes #282). String
+  columns were previously hard-coded to right-align in `getColumnClassName`
+  with no user-visible knob. Two complementary controls:
+  - New panel-level **Right Align Text** toggle (`alignStringsToRightEnabled`,
+    default `true`). Disabling it lets string columns inherit the DataTables
+    default (left-aligned).
+  - New per-column **Cell Alignment** Select on each column style
+    (`ColumnStyleItemType.align`, values `default | left | center | right`).
+    A non-`default` value paints an inline `text-align` on each matching cell
+    that overrides the panel-level class. Applies to any `activeStyle`
+    (metric / string / date), so the same knob covers all column types.
+  - Defaults preserve today's right-aligned behavior; the option migrates
+    to `true` and new column styles seed `align='default'`.
+  - Covered by new unit cases (migration defaults, Cell Alignment emit,
+    addItem seed) and an e2e spec
+    (`tests/phase3-panel/text-alignment.spec.ts`) that loads a provisioned
+    dashboard and asserts an inline `text-align: left` style is applied.
+
 ### Scaffolding & Configuration
 
 - Update `@grafana/create-plugin` from 5.27.1 to 7.1.7, applying all scaffolding migrations:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ per-cell filtering.
 * Rows can have a click-through URL
 * Multi-Column Sorting
 * Horizontal scrolling enabled when columns are wider than panel
+* Configurable text alignment (panel-level default plus per-column override)
 
 ## Screenshots
 
@@ -83,17 +84,19 @@ Show rows per page selection
 
 #### Other options
 
-| Option                 | Meaning                                               |
-| ---------------------- | ----------------------------------------------------- |
-| Enable Row Numbers     | Adds left column showing row numbers                  |
-| Font Size              | Adjust font size of text in table                     |
-| Highlight Order Column | When the column order is modified, this highlights it |
-| Hover                  | Highlight row under mouse                             |
-| Right Align Numbers    | All cells with numbers will be aligned to the right   |
-| Show Footer Info       | Displays number of rows                               |
-| Show Stripes on Rows   | Alternating stripes for even/odd rows                 |
-| Use Compact Rows       | Reduce space used to display data                     |
-| Wrap Row Content       | Auto-wraps text to fit in column width                |
+| Option                 | Meaning                                                  |
+| ---------------------- | -------------------------------------------------------- |
+| Enable Row Numbers     | Adds left column showing row numbers                     |
+| Font Size              | Adjust font size of text in table                        |
+| Highlight Order Column | When the column order is modified, this highlights it    |
+| Hover                  | Highlight row under mouse                                |
+| Right Align Numbers    | All cells with numbers will be aligned to the right      |
+| Right Align Text       | All cells with string/text values will be right-aligned; |
+|                        | disable to let string columns use the default alignment  |
+| Show Footer Info       | Displays number of rows                                  |
+| Show Stripes on Rows   | Alternating stripes for even/odd rows                    |
+| Use Compact Rows       | Reduce space used to display data                        |
+| Wrap Row Content       | Auto-wraps text to fit in column width                   |
 
 ### Search Options
 
@@ -139,6 +142,20 @@ There are four styles that can be applied to the datatable.
 NOTE: The first style that matches "wins" and all other style matches are ignored.
 
 Support for multiple styles is a future enhancement, where a string and a metric style can be applied to the same cell.
+
+### Common Column Style Properties
+
+Every column style — Date, String, Hidden, and Metric — shares the
+following properties in addition to its style-specific settings:
+
+| Property       | Meaning                                                      |
+| -------------- | ------------------------------------------------------------ |
+| Label          | Name of this style as shown in the options editor            |
+| Metric/RegEx   | Column name or regex that selects which columns this applies |
+| Cell Alignment | `Default` defers to the panel-level Right Align Numbers /    |
+|                | Right Align Text settings; `Left`, `Center`, or `Right` set  |
+|                | an explicit `text-align` on each matching cell               |
+| Enabled        | Toggles this style without deleting it                       |
 
 ### Date Style
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -7,12 +7,19 @@
     "dist/**",
     "coverage/**",
     "provisioning/**",
-    "src/dashboards/**"
+    "src/dashboards/**",
+    "importable/**",
+    "TODO.md",
+    "pnpm-lock.yaml",
+    "provisioning-private/**"
   ],
   "words": [
+    "briangann",
     "buildno",
     "Cascader",
+    "Clickthrough",
     "columnstyles",
+    "dataframes",
     "Datatable",
     "datatables",
     "DATETIME",
@@ -21,9 +28,14 @@
     "fixedcolumns",
     "fixedheader",
     "framename",
+    "Gann",
+    "gdev",
+    "isopen",
     "jqui",
     "keytable",
+    "logmin",
     "loopfunc",
+    "Magefile",
     "markjs",
     "pdfmake",
     "rowcolumn",
@@ -32,6 +44,8 @@
     "searchpanes",
     "showreport",
     "sourcedir",
-    "subresource"
+    "SSSZ",
+    "subresource",
+    "testdata"
   ]
 }

--- a/provisioning/dashboards/dashboards/Datatable-TextAlignment.json
+++ b/provisioning/dashboards/dashboards/Datatable-TextAlignment.json
@@ -1,0 +1,145 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 6,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource",
+        "uid": "P53465F745837BCFD"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "alignNumbersToRightEnabled": true,
+        "alignStringsToRightEnabled": true,
+        "columnAliases": [],
+        "columnFiltersEnabled": false,
+        "columnSorting": [
+          {
+            "index": 0,
+            "order": "asc"
+          }
+        ],
+        "columnStylesConfig": [
+          {
+            "activeStyle": "metric",
+            "align": "left",
+            "dateStyle": {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss"
+            },
+            "enabled": true,
+            "hiddenStyle": {},
+            "label": "A-series-left",
+            "metricStyle": {
+              "alias": "",
+              "colorMode": "disabled",
+              "colors": [
+                "#299c46",
+                "#ed8128",
+                "#f53636",
+                "#0a55a1"
+              ],
+              "decimals": "2",
+              "ignoreNullValues": true,
+              "thresholds": [],
+              "unitFormat": "short"
+            },
+            "nameOrRegex": "A-series",
+            "order": 0,
+            "stringStyle": {
+              "clickThrough": "",
+              "clickThroughCustomTarget": "",
+              "clickThroughCustomTargetEnabled": false,
+              "clickThroughOpenNewTab": true,
+              "clickThroughSanitize": true,
+              "splitByPattern": ""
+            }
+          }
+        ],
+        "columnWidthHints": [],
+        "columns": [],
+        "compactRowsEnabled": false,
+        "datatablePagingType": "simple_numbers",
+        "emptyDataEnabled": true,
+        "emptyDataText": "",
+        "fontSizePercent": "100%",
+        "hoverEnabled": true,
+        "infoEnabled": true,
+        "lengthChangeEnabled": true,
+        "orderColumnEnabled": false,
+        "rowNumbersEnabled": false,
+        "rowsPerPage": 5,
+        "scroll": true,
+        "searchEnabled": false,
+        "searchHighlightingEnabled": false,
+        "stripedRowsEnabled": true,
+        "transformation": "timeseries-to-columns",
+        "transformationAggregations": [
+          "last"
+        ],
+        "wrapToFitEnabled": true
+      },
+      "pluginVersion": "2.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "P53465F745837BCFD"
+          },
+          "max": 30,
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "spread": 12,
+          "startValue": 5
+        }
+      ],
+      "title": "Datatable-Text-Alignment-Override",
+      "type": "briangann-datatable-panel"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Datatable-TextAlignment",
+  "uid": "align-282-test",
+  "version": 1
+}

--- a/provisioning/dashboards/dashboards/Datatable-TextAlignmentPanelLevel.json
+++ b/provisioning/dashboards/dashboards/Datatable-TextAlignmentPanelLevel.json
@@ -1,0 +1,103 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 7,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource",
+        "uid": "P53465F745837BCFD"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "alignNumbersToRightEnabled": true,
+        "alignStringsToRightEnabled": false,
+        "columnAliases": [],
+        "columnFiltersEnabled": false,
+        "columnSorting": [],
+        "columnStylesConfig": [],
+        "columnWidthHints": [],
+        "columns": [],
+        "compactRowsEnabled": false,
+        "datatablePagingType": "simple_numbers",
+        "emptyDataEnabled": true,
+        "emptyDataText": "",
+        "fontSizePercent": "100%",
+        "hoverEnabled": true,
+        "infoEnabled": true,
+        "lengthChangeEnabled": true,
+        "orderColumnEnabled": false,
+        "rowNumbersEnabled": false,
+        "rowsPerPage": 5,
+        "scroll": true,
+        "searchEnabled": false,
+        "searchHighlightingEnabled": false,
+        "stripedRowsEnabled": true,
+        "transformation": "table",
+        "transformationAggregations": [
+          "last"
+        ],
+        "wrapToFitEnabled": true
+      },
+      "pluginVersion": "2.0.2",
+      "targets": [
+        {
+          "csvContent": "Name,Value\nAlpha,1\nBravo,2\nCharlie,3",
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Datatable-Text-Alignment-Panel-Level",
+      "type": "briangann-datatable-panel"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Datatable-TextAlignmentPanelLevel",
+  "uid": "align-282-panel",
+  "version": 1
+}

--- a/src/__snapshots__/migrations.test.ts.snap
+++ b/src/__snapshots__/migrations.test.ts.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Datatable -> DatatableV2 migrations migrates old datatable config 1`] = `{}`;
+exports[`Datatable -> DatatableV2 migrations migrates old datatable config 1`] = `
+{
+  "alignStringsToRightEnabled": true,
+}
+`;

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -22,7 +22,7 @@ import { LoadingState, PanelProps, textUtil } from '@grafana/data';
 
 import { useStyles2, useTheme2 } from '@grafana/ui';
 import { useApplyTransformation } from 'hooks/useApplyTransformation';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { DatatableOptions } from 'types';
 import { BuildColumnDefs, ConvertDataFrameToDataTableFormat } from 'data/dataHelpers';
 import { ApplyColumnWidthHints } from 'data/columnWidthHints';
@@ -54,6 +54,18 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
   // convert the option to a usable type
   const transformID = GetDataTransformerID(props.options.transformation);
   const dataFrames = useApplyTransformation(props.data.series, transformID, props.options.transformationAggregations);
+
+  // Stable reference so the dep arrays below can depend on a single value
+  // without re-triggering every render. If the object were rebuilt inline
+  // at the call sites, dropping it into a dep array would cause an
+  // infinite loop; using the memoized value makes that invariant explicit.
+  const alignment = useMemo(
+    () => ({
+      numbers: props.options.alignNumbersToRightEnabled,
+      strings: props.options.alignStringsToRightEnabled,
+    }),
+    [props.options.alignNumbersToRightEnabled, props.options.alignStringsToRightEnabled],
+  );
 
   const enableColumnFilters = (dataTable: any) => {
     const header = dataTable.table(0).header();
@@ -123,19 +135,15 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
         props.options.emptyDataText,
         props.options.rowNumbersEnabled,
         props.options.fontSizePercent,
-        {
-          numbers: props.options.alignNumbersToRightEnabled,
-          strings: props.options.alignStringsToRightEnabled,
-        },
+        alignment,
         props.timeRange,
         cachedProcessedData);
       setCachedColumnDefs(calcColumnDefs);
     }
   }, [
+    alignment,
     cachedProcessedData,
     props.timeRange,
-    props.options.alignNumbersToRightEnabled,
-    props.options.alignStringsToRightEnabled,
     props.options.emptyDataEnabled,
     props.options.emptyDataText,
     props.options.fontSizePercent,
@@ -155,10 +163,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
           props.fieldConfig,
           props.timeZone,
           props.timeRange,
-          {
-            numbers: props.options.alignNumbersToRightEnabled,
-            strings: props.options.alignStringsToRightEnabled,
-          },
+          alignment,
           props.options.rowNumbersEnabled,
           props.options.columnStylesConfig,
           theme2);
@@ -175,14 +180,13 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
       }
     }
   }, [
+    alignment,
     dataFrames,
     props.fieldConfig,
     props.timeZone,
     props.timeRange,
     props.data.state,
     props.data.series,
-    props.options.alignNumbersToRightEnabled,
-    props.options.alignStringsToRightEnabled,
     props.options.columnAliases,
     props.options.columnStylesConfig,
     props.options.columnWidthHints,
@@ -279,12 +283,11 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
       }
     }
   }, [
+    alignment,
     dataTableClassesEnabled,
     cachedProcessedData,
     cachedColumnDefs,
     props.height,
-    props.options.alignNumbersToRightEnabled,
-    props.options.alignStringsToRightEnabled,
     props.options.columnAliases,
     props.options.columnFiltersEnabled,
     props.options.columnSorting,

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -123,8 +123,10 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
         props.options.emptyDataText,
         props.options.rowNumbersEnabled,
         props.options.fontSizePercent,
-        props.options.alignNumbersToRightEnabled,
-        props.options.alignStringsToRightEnabled ?? true,
+        {
+          numbers: props.options.alignNumbersToRightEnabled,
+          strings: props.options.alignStringsToRightEnabled ?? true,
+        },
         props.timeRange,
         cachedProcessedData);
       setCachedColumnDefs(calcColumnDefs);
@@ -153,8 +155,10 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
           props.fieldConfig,
           props.timeZone,
           props.timeRange,
-          props.options.alignNumbersToRightEnabled,
-          props.options.alignStringsToRightEnabled ?? true,
+          {
+            numbers: props.options.alignNumbersToRightEnabled,
+            strings: props.options.alignStringsToRightEnabled ?? true,
+          },
           props.options.rowNumbersEnabled,
           props.options.columnStylesConfig,
           theme2);

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -124,6 +124,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
         props.options.rowNumbersEnabled,
         props.options.fontSizePercent,
         props.options.alignNumbersToRightEnabled,
+        props.options.alignStringsToRightEnabled ?? true,
         props.timeRange,
         cachedProcessedData);
       setCachedColumnDefs(calcColumnDefs);
@@ -132,6 +133,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     cachedProcessedData,
     props.timeRange,
     props.options.alignNumbersToRightEnabled,
+    props.options.alignStringsToRightEnabled,
     props.options.emptyDataEnabled,
     props.options.emptyDataText,
     props.options.fontSizePercent,
@@ -152,6 +154,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
           props.timeZone,
           props.timeRange,
           props.options.alignNumbersToRightEnabled,
+          props.options.alignStringsToRightEnabled ?? true,
           props.options.rowNumbersEnabled,
           props.options.columnStylesConfig,
           theme2);
@@ -175,6 +178,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     props.data.state,
     props.data.series,
     props.options.alignNumbersToRightEnabled,
+    props.options.alignStringsToRightEnabled,
     props.options.columnAliases,
     props.options.columnStylesConfig,
     props.options.columnWidthHints,
@@ -276,6 +280,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     cachedColumnDefs,
     props.height,
     props.options.alignNumbersToRightEnabled,
+    props.options.alignStringsToRightEnabled,
     props.options.columnAliases,
     props.options.columnFiltersEnabled,
     props.options.columnSorting,

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -125,7 +125,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
         props.options.fontSizePercent,
         {
           numbers: props.options.alignNumbersToRightEnabled,
-          strings: props.options.alignStringsToRightEnabled ?? true,
+          strings: props.options.alignStringsToRightEnabled,
         },
         props.timeRange,
         cachedProcessedData);
@@ -157,7 +157,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
           props.timeRange,
           {
             numbers: props.options.alignNumbersToRightEnabled,
-            strings: props.options.alignStringsToRightEnabled ?? true,
+            strings: props.options.alignStringsToRightEnabled,
           },
           props.options.rowNumbersEnabled,
           props.options.columnStylesConfig,

--- a/src/components/options/columnstyles/ColumnStyleItem.test.tsx
+++ b/src/components/options/columnstyles/ColumnStyleItem.test.tsx
@@ -116,13 +116,43 @@ describe('ColumnStyleItem', () => {
     });
   });
 
-  it('Cell Alignment selection emits the chosen align value', () => {
+  it.each([
+    [ColumnAlignment.LEFT],
+    [ColumnAlignment.CENTER],
+    [ColumnAlignment.RIGHT],
+  ])('Cell Alignment selection emits align=%s', (expected) => {
     const setter = renderItem();
 
-    fireEvent.click(screen.getByTestId('option-left'));
+    fireEvent.click(screen.getByTestId(`option-${expected}`));
 
     const [order, emitted] = setter.mock.calls.at(-1)!;
     expect(order).toBe(0);
-    expect(emitted.align).toBe(ColumnAlignment.LEFT);
+    expect(emitted.align).toBe(expected);
+  });
+
+  it('Cell Alignment Select falls back to "default" when style.align is undefined', () => {
+    // The Select stub exposes the `value` prop via its data-testid. A style
+    // built without an `align` field (e.g. a pre-#282 migrated panel whose
+    // applyOptionDefaults has not yet stamped one) should surface as
+    // ColumnAlignment.DEFAULT in the editor so the UI matches the runtime
+    // behavior.
+    const setter = jest.fn();
+    const style = { ...makeStyle(), align: undefined } as any;
+    render(
+      <ColumnStyleItem
+        ID="uuid-1"
+        style={style}
+        enabled={true}
+        columnHints={[]}
+        context={{} as any}
+        setter={setter}
+        remover={jest.fn()}
+        moveUp={jest.fn()}
+        moveDown={jest.fn()}
+        createDuplicate={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId(`select-value-${ColumnAlignment.DEFAULT}`)).toBeInTheDocument();
   });
 });

--- a/src/components/options/columnstyles/ColumnStyleItem.test.tsx
+++ b/src/components/options/columnstyles/ColumnStyleItem.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ColumnStyleItem } from './ColumnStyleItem';
-import { ColumnStyles, type ColumnStyleItemType } from './types';
+import { ColumnAlignment, ColumnStyles, type ColumnStyleItemType } from './types';
 import { ColumnStyleColoring, DateFormats } from 'types';
 import type { Threshold } from '../thresholds/types';
 
@@ -19,6 +19,29 @@ jest.mock('../thresholds/ThresholdsEditor', () => ({
     </button>
   ),
 }));
+
+// @grafana/ui Select uses react-select internally, which is painful to drive
+// from tests. Replace it with a button-per-option passthrough so tests can
+// trigger onChange deterministically.
+jest.mock('@grafana/ui', () => {
+  const actual = jest.requireActual('@grafana/ui');
+  return {
+    ...actual,
+    Select: ({ value, onChange, options }: any) => (
+      <div data-testid={`select-value-${value}`}>
+        {(options ?? []).map((opt: any) => (
+          <button
+            key={opt.value}
+            data-testid={`option-${opt.value}`}
+            onClick={() => onChange(opt)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    ),
+  };
+});
 
 const makeStyle = (): ColumnStyleItemType => ({
   label: 'Style-0',
@@ -91,5 +114,15 @@ describe('ColumnStyleItem', () => {
       unitFormat: 'percent',
       ignoreNullValues: false,
     });
+  });
+
+  it('Cell Alignment selection emits the chosen align value', () => {
+    const setter = renderItem();
+
+    fireEvent.click(screen.getByTestId('option-left'));
+
+    const [order, emitted] = setter.mock.calls.at(-1)!;
+    expect(order).toBe(0);
+    expect(emitted.align).toBe(ColumnAlignment.LEFT);
   });
 });

--- a/src/components/options/columnstyles/ColumnStyleItem.test.tsx
+++ b/src/components/options/columnstyles/ColumnStyleItem.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ColumnStyleItem } from './ColumnStyleItem';
-import { ColumnAlignment, ColumnStyles, type ColumnStyleItemType } from './types';
-import { ColumnStyleColoring, DateFormats } from 'types';
+import { ColumnStyles, type ColumnStyleItemType } from './types';
+import { ColumnAlignment, ColumnStyleColoring, DateFormats } from 'types';
 import type { Threshold } from '../thresholds/types';
 
 // Stub ThresholdsEditor so we can invoke its `setter` directly from a test

--- a/src/components/options/columnstyles/ColumnStyleItem.tsx
+++ b/src/components/options/columnstyles/ColumnStyleItem.tsx
@@ -12,7 +12,7 @@ import {
   Cascader,
   Select,
 } from '@grafana/ui';
-import { ColumnStyleItemProps, ColumnStyleItemType } from './types';
+import { ColumnAlignment, ColumnAlignmentOptions, ColumnStyleItemProps, ColumnStyleItemType } from './types';
 import { ThresholdsEditor } from '../thresholds/ThresholdsEditor';
 import { Threshold } from '../thresholds/types';
 import { ColorModeOptions, DateFormats } from 'types';
@@ -275,6 +275,19 @@ export const ColumnStyleItem: React.FC<ColumnStyleItemProps> = (props) => {
               )}
             options={props.columnHints}
           />
+          </Field>
+
+          <Field
+            label="Cell Alignment"
+            description="Overrides the panel-level text/number alignment for this column"
+            disabled={!style.enabled}
+          >
+            <Select
+              menuShouldPortal={true}
+              value={style.align ?? ColumnAlignment.DEFAULT}
+              onChange={(item) => setColumnStyle({ ...style, align: item.value })}
+              options={ColumnAlignmentOptions}
+            />
           </Field>
 
           {style.activeStyle === 'metric' && metricItemType() }

--- a/src/components/options/columnstyles/ColumnStyleItem.tsx
+++ b/src/components/options/columnstyles/ColumnStyleItem.tsx
@@ -12,10 +12,10 @@ import {
   Cascader,
   Select,
 } from '@grafana/ui';
-import { ColumnAlignment, ColumnAlignmentOptions, ColumnStyleItemProps, ColumnStyleItemType } from './types';
+import { ColumnStyleItemProps, ColumnStyleItemType } from './types';
 import { ThresholdsEditor } from '../thresholds/ThresholdsEditor';
 import { Threshold } from '../thresholds/types';
-import { ColorModeOptions, DateFormats } from 'types';
+import { ColorModeOptions, ColumnAlignment, ColumnAlignmentOptions, DateFormats } from 'types';
 import { SelectableValue } from '@grafana/data';
 
 export const ColumnStyleItem: React.FC<ColumnStyleItemProps> = (props) => {

--- a/src/components/options/columnstyles/ColumnStylesEditor.test.tsx
+++ b/src/components/options/columnstyles/ColumnStylesEditor.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ColumnStylesEditor } from './ColumnStylesEditor';
-import { ColumnAlignment, ColumnStyles, type ColumnStyleItemType } from './types';
-import { ColumnStyleColoring, DateFormats } from 'types';
+import { ColumnStyles, type ColumnStyleItemType } from './types';
+import { ColumnAlignment, ColumnStyleColoring, DateFormats } from 'types';
 
 jest.mock('./ColumnStyleItem', () => ({
   ColumnStyleItem: ({

--- a/src/components/options/columnstyles/ColumnStylesEditor.test.tsx
+++ b/src/components/options/columnstyles/ColumnStylesEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ColumnStylesEditor } from './ColumnStylesEditor';
-import { ColumnStyles, type ColumnStyleItemType } from './types';
+import { ColumnAlignment, ColumnStyles, type ColumnStyleItemType } from './types';
 import { ColumnStyleColoring, DateFormats } from 'types';
 
 jest.mock('./ColumnStyleItem', () => ({
@@ -185,6 +185,23 @@ describe('ColumnStylesEditor', () => {
     const emitted = onChange.mock.calls.at(-1)![0] as ColumnStyleItemType[];
     expect(emitted).toHaveLength(2);
     expect(emitted[1].order).toBe(1);
+  });
+
+  it('Add Style stamps align=default on the new tracker', () => {
+    const onChange = jest.fn();
+    const styles = [makeStyle(0, 'A')];
+    render(
+      <ColumnStylesEditor
+        {...({} as any)}
+        context={buildContext(styles)}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Style' }));
+
+    const emitted = onChange.mock.calls.at(-1)![0] as ColumnStyleItemType[];
+    expect(emitted[1].align).toBe(ColumnAlignment.DEFAULT);
   });
 
   it('Add Style opens the newly-added collapse by ID', () => {

--- a/src/components/options/columnstyles/ColumnStylesEditor.test.tsx
+++ b/src/components/options/columnstyles/ColumnStylesEditor.test.tsx
@@ -254,6 +254,27 @@ describe('ColumnStylesEditor', () => {
     expect(screen.getByTestId('collapse-A')).toHaveAttribute('data-isopen', 'false');
   });
 
+  it('createDuplicate carries the source align through to the copy', () => {
+    // createDuplicate uses a spread-with-overrides on the source style; any
+    // field not explicitly overridden should ride along, including align.
+    // Pin this so a future re-write that hand-enumerates metricStyle-style
+    // fields (the bug class that cost us colorMode) can't silently drop it.
+    const onChange = jest.fn();
+    const source: ColumnStyleItemType = { ...makeStyle(0, 'A'), align: ColumnAlignment.CENTER };
+    render(
+      <ColumnStylesEditor
+        {...({} as any)}
+        context={buildContext([source])}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'duplicate' }));
+
+    const emitted = onChange.mock.calls.at(-1)![0] as ColumnStyleItemType[];
+    expect(emitted[1].align).toBe(ColumnAlignment.CENTER);
+  });
+
   it('moveDown swaps neighbors and re-numbers both order and style.order', () => {
     const onChange = jest.fn();
     const styles = [makeStyle(0, 'A'), makeStyle(1, 'B')];

--- a/src/components/options/columnstyles/ColumnStylesEditor.tsx
+++ b/src/components/options/columnstyles/ColumnStylesEditor.tsx
@@ -9,6 +9,7 @@ import {
   DEFAULT_WARNING_COLOR_HEX,
 } from '../defaults';
 import {
+  ColumnAlignment,
   ColumnStyles,
   ColumnStyleDate,
   ColumnStyleHidden,
@@ -87,6 +88,7 @@ export const ColumnStylesEditor: React.FC<StandardEditorProps<ColumnStyleItemTyp
       nameOrRegex: '',
       order,
       enabled: true,
+      align: ColumnAlignment.DEFAULT,
       dateStyle: { dateFormat: DateFormats[0].value } as ColumnStyleDate,
       hiddenStyle: {} as ColumnStyleHidden,
       metricStyle: {

--- a/src/components/options/columnstyles/ColumnStylesEditor.tsx
+++ b/src/components/options/columnstyles/ColumnStylesEditor.tsx
@@ -9,7 +9,6 @@ import {
   DEFAULT_WARNING_COLOR_HEX,
 } from '../defaults';
 import {
-  ColumnAlignment,
   ColumnStyles,
   ColumnStyleDate,
   ColumnStyleHidden,
@@ -21,7 +20,7 @@ import {
 import { ColumnStyleItem } from './ColumnStyleItem';
 import { Threshold } from '../thresholds/types';
 import { getColumnHints } from './columnHints';
-import { ColumnStyleColoring, DateFormats } from 'types';
+import { ColumnAlignment, ColumnStyleColoring, DateFormats } from 'types';
 import { TrackerAdapter, useTracker } from 'hooks/useTracker';
 
 const columnStyleAdapter: TrackerAdapter<ColumnStyleItemTracker, ColumnStyleItemType> = {

--- a/src/components/options/columnstyles/types.ts
+++ b/src/components/options/columnstyles/types.ts
@@ -47,6 +47,21 @@ export enum ColumnStyles {
   METRIC = 'metric',
   STRING = 'string',
 }
+
+export enum ColumnAlignment {
+  DEFAULT = 'default',
+  LEFT = 'left',
+  CENTER = 'center',
+  RIGHT = 'right',
+}
+
+export const ColumnAlignmentOptions = [
+  { label: 'Default', value: ColumnAlignment.DEFAULT },
+  { label: 'Left', value: ColumnAlignment.LEFT },
+  { label: 'Center', value: ColumnAlignment.CENTER },
+  { label: 'Right', value: ColumnAlignment.RIGHT },
+];
+
 export interface ColumnStyleItemType {
   // common properties
   activeStyle: ColumnStyles;
@@ -54,6 +69,8 @@ export interface ColumnStyleItemType {
   label: string;
   nameOrRegex: string;
   order: number;
+  // per-column cell alignment override; 'default' defers to the panel-level setting
+  align?: ColumnAlignment;
   // allows switching the styles without losing data
   dateStyle: ColumnStyleDate;
   hiddenStyle: ColumnStyleHidden;

--- a/src/components/options/columnstyles/types.ts
+++ b/src/components/options/columnstyles/types.ts
@@ -1,5 +1,6 @@
 import { CascaderOption } from '@grafana/ui';
 import { Threshold } from '../thresholds/types';
+import { ColumnAlignment } from 'types';
 
 export interface ColumnStyleItemProps {
   columnHints: CascaderOption[];
@@ -47,20 +48,6 @@ export enum ColumnStyles {
   METRIC = 'metric',
   STRING = 'string',
 }
-
-export enum ColumnAlignment {
-  DEFAULT = 'default',
-  LEFT = 'left',
-  CENTER = 'center',
-  RIGHT = 'right',
-}
-
-export const ColumnAlignmentOptions = [
-  { label: 'Default', value: ColumnAlignment.DEFAULT },
-  { label: 'Left', value: ColumnAlignment.LEFT },
-  { label: 'Center', value: ColumnAlignment.CENTER },
-  { label: 'Right', value: ColumnAlignment.RIGHT },
-];
 
 export interface ColumnStyleItemType {
   // common properties

--- a/src/components/options/optionsBuilder.tsx
+++ b/src/components/options/optionsBuilder.tsx
@@ -74,6 +74,14 @@ export async function optionsBuilder(
     category: ['Visual Options'],
     description: 'Any cell with a numeric value will be aligned to the right'
   });
+  // rightAlignText
+  builder.addBooleanSwitch({
+    name: 'Right Align Text',
+    path: 'alignStringsToRightEnabled',
+    defaultValue: true,
+    category: ['Visual Options'],
+    description: 'Any cell with a string/text value will be aligned to the right (disable for left-alignment)'
+  });
 
     // Info Enabled
   builder.addBooleanSwitch({

--- a/src/data/dataHelpers.test.ts
+++ b/src/data/dataHelpers.test.ts
@@ -1,0 +1,30 @@
+import { getColumnClassName } from './dataHelpers';
+
+// getColumnClassName is the gate that turns the panel-level alignment toggles
+// into a DataTables class on each column. The per-column override runs later
+// in createdCell as an inline text-align. Pinning the branch table here makes
+// the #282 contract (strings can be un-right-aligned) a hard test, not an
+// implementation detail that future refactors could silently flip.
+describe('getColumnClassName', () => {
+  const both = { numbers: true, strings: true };
+  const neither = { numbers: false, strings: false };
+
+  it.each([
+    ['number', both, 'dt-right'],
+    ['number', neither, ''],
+    ['number', { numbers: true, strings: false }, 'dt-right'],
+    ['string', both, 'dt-right'],
+    ['string', neither, ''],
+    ['string', { numbers: false, strings: true }, 'dt-right'],
+    ['string', { numbers: true, strings: false }, ''],
+    // time columns are coerced to number for alignment purposes
+    ['time', both, 'dt-right'],
+    ['time', neither, ''],
+    ['time', { numbers: true, strings: false }, 'dt-right'],
+    // date and any other type never get dt-right
+    ['date', both, ''],
+    ['boolean', both, ''],
+  ])('%s column with alignment=%j → %s', (columnType, alignment, expected) => {
+    expect(getColumnClassName(alignment, columnType)).toBe(expected);
+  });
+});

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -10,9 +10,9 @@ import {
 import { FormatColumnValue } from 'data/cellRenderer';
 import { ApplyGrafanaOverrides } from './overrides';
 import { CellMetaSettings, ConfigColumnDefs } from 'datatables.net';
-import { ColumnStyleColoring } from 'types';
+import { ColumnAlignment, ColumnStyleColoring } from 'types';
 import { DTColumnType, FormattedColumnValue } from './types';
-import { ColumnAlignment, ColumnStyleItemType, ColumnStyles } from 'components/options/columnstyles/types';
+import { ColumnStyleItemType, ColumnStyles } from 'components/options/columnstyles/types';
 import { ApplyColumnStyles } from './columnStyles';
 import { DTData } from 'components/DataTablePanel';
 import { processRowColumnStyle, processRowStyle, ProcessStringValueStyle } from './createdCellHelpers';

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -10,7 +10,7 @@ import {
 import { FormatColumnValue } from 'data/cellRenderer';
 import { ApplyGrafanaOverrides } from './overrides';
 import { CellMetaSettings, ConfigColumnDefs } from 'datatables.net';
-import { ColumnAlignment, ColumnStyleColoring } from 'types';
+import { ColumnAlignment, ColumnAlignmentOptions, ColumnStyleColoring } from 'types';
 import { DTColumnType, FormattedColumnValue } from './types';
 import { ColumnStyleItemType, ColumnStyles } from 'components/options/columnstyles/types';
 import { ApplyColumnStyles } from './columnStyles';
@@ -54,13 +54,17 @@ export const DataFrameToDisplay = (frames: DataFrame[]) => {
 };
 
 
+export type AlignmentFlags = {
+  numbers: boolean;
+  strings: boolean;
+};
+
 export const ConvertDataFrameToDataTableFormat = (
   dataFrames: DataFrame[],
   fieldConfig: FieldConfigSource<any>,
   userTimeZone: string,
   timeRange: TimeRange,
-  alignNumbersToRightEnabled: boolean,
-  alignStringsToRightEnabled: boolean,
+  alignment: AlignmentFlags,
   rowNumbersEnabled: boolean,
   columnStyles: ColumnStyleItemType[],
   theme: GrafanaTheme2): { columns: DTColumnType[]; rows: any[] } => {
@@ -68,7 +72,7 @@ export const ConvertDataFrameToDataTableFormat = (
   dataFrames = ApplyGrafanaOverrides(dataFrames, theme);
   const dataFrame = dataFrames[0];
   let columns: DTColumnType[] = dataFrame.fields.map((field) => {
-    const columnClassName = getColumnClassName(alignNumbersToRightEnabled, alignStringsToRightEnabled, field.type as string)
+    const columnClassName = getColumnClassName(alignment, field.type as string)
     return {
       title: field.name,
       data: normalizeFieldName(field.name),
@@ -146,8 +150,7 @@ export const BuildColumnDefs = (
   emptyDataText: string,
   rowNumbersEnabled: boolean,
   fontSizePercent: string,
-  alignNumbersToRightEnabled: boolean,
-  alignStringsToRightEnabled: boolean,
+  alignment: AlignmentFlags,
   timeRange: TimeRange,
   dtData: DTData): ConfigColumnDefs[] => {
 
@@ -155,14 +158,14 @@ export const BuildColumnDefs = (
   let rowNumberOffset = 0;
   for (let i = 0; i < dtData.Columns.length; i++) {
     let columnType = dtData.Columns[i].type!;
-    let columnClassName = getColumnClassName(alignNumbersToRightEnabled, alignStringsToRightEnabled, columnType)
+    let columnClassName = getColumnClassName(alignment, columnType)
     // column type "date" is very limited, and overrides our formatting
     // best to use our format, then the "raw" epoch time as the sort ordering field
     // https://datatables.net/reference/option/columns.type
     if (columnType === 'time') {
       columnType = 'number';
     }
-    if (columnType === 'number' && alignNumbersToRightEnabled) {
+    if (columnType === 'number' && alignment.numbers) {
       columnClassName = 'dt-right'; // any reason not to align numbers right?
     }
     // if we did not get a type prop from grafana at all,
@@ -315,7 +318,14 @@ export const BuildColumnDefs = (
         }
 
         // Per-column alignment override — wins over the DataTables class set via getColumnClassName.
-        if (aStyle.align && aStyle.align !== ColumnAlignment.DEFAULT) {
+        // Whitelist against the known enum so hand-crafted panel JSON can't feed arbitrary strings
+        // into jQuery's .css(). Not a present-day exploit (browsers reject invalid text-align) but
+        // cheap defense-in-depth at a boundary that reads user-controlled data.
+        if (
+          aStyle.align &&
+          aStyle.align !== ColumnAlignment.DEFAULT &&
+          ColumnAlignmentOptions.some((o) => o.value === aStyle.align)
+        ) {
           $(cell).css('text-align', aStyle.align);
         }
       },
@@ -346,11 +356,7 @@ export const BuildColumnDefs = (
   return columnDefs;
 };
 
-const getColumnClassName = (
-  alignNumbersToRightEnabled: boolean,
-  alignStringsToRightEnabled: boolean,
-  columnType: string,
-) => {
+const getColumnClassName = (alignment: AlignmentFlags, columnType: string) => {
   let columnClassName = '';
 
   // column type "date" is very limited, and overrides our formatting
@@ -359,10 +365,10 @@ const getColumnClassName = (
   if (columnType === 'time') {
     columnType = 'number';
   }
-  if (columnType === 'number' && alignNumbersToRightEnabled) {
+  if (columnType === 'number' && alignment.numbers) {
     columnClassName = 'dt-right'; // any reason not to align numbers right?
   }
-  if (columnType === 'string' && alignStringsToRightEnabled) {
+  if (columnType === 'string' && alignment.strings) {
     columnClassName = 'dt-right';
   }
   return columnClassName;

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -12,7 +12,7 @@ import { ApplyGrafanaOverrides } from './overrides';
 import { CellMetaSettings, ConfigColumnDefs } from 'datatables.net';
 import { ColumnStyleColoring } from 'types';
 import { DTColumnType, FormattedColumnValue } from './types';
-import { ColumnStyleItemType, ColumnStyles } from 'components/options/columnstyles/types';
+import { ColumnAlignment, ColumnStyleItemType, ColumnStyles } from 'components/options/columnstyles/types';
 import { ApplyColumnStyles } from './columnStyles';
 import { DTData } from 'components/DataTablePanel';
 import { processRowColumnStyle, processRowStyle, ProcessStringValueStyle } from './createdCellHelpers';
@@ -60,6 +60,7 @@ export const ConvertDataFrameToDataTableFormat = (
   userTimeZone: string,
   timeRange: TimeRange,
   alignNumbersToRightEnabled: boolean,
+  alignStringsToRightEnabled: boolean,
   rowNumbersEnabled: boolean,
   columnStyles: ColumnStyleItemType[],
   theme: GrafanaTheme2): { columns: DTColumnType[]; rows: any[] } => {
@@ -67,7 +68,7 @@ export const ConvertDataFrameToDataTableFormat = (
   dataFrames = ApplyGrafanaOverrides(dataFrames, theme);
   const dataFrame = dataFrames[0];
   let columns: DTColumnType[] = dataFrame.fields.map((field) => {
-    const columnClassName = getColumnClassName(alignNumbersToRightEnabled, field.type as string)
+    const columnClassName = getColumnClassName(alignNumbersToRightEnabled, alignStringsToRightEnabled, field.type as string)
     return {
       title: field.name,
       data: normalizeFieldName(field.name),
@@ -146,6 +147,7 @@ export const BuildColumnDefs = (
   rowNumbersEnabled: boolean,
   fontSizePercent: string,
   alignNumbersToRightEnabled: boolean,
+  alignStringsToRightEnabled: boolean,
   timeRange: TimeRange,
   dtData: DTData): ConfigColumnDefs[] => {
 
@@ -153,7 +155,7 @@ export const BuildColumnDefs = (
   let rowNumberOffset = 0;
   for (let i = 0; i < dtData.Columns.length; i++) {
     let columnType = dtData.Columns[i].type!;
-    let columnClassName = getColumnClassName(alignNumbersToRightEnabled, columnType)
+    let columnClassName = getColumnClassName(alignNumbersToRightEnabled, alignStringsToRightEnabled, columnType)
     // column type "date" is very limited, and overrides our formatting
     // best to use our format, then the "raw" epoch time as the sort ordering field
     // https://datatables.net/reference/option/columns.type
@@ -312,6 +314,10 @@ export const BuildColumnDefs = (
           }
         }
 
+        // Per-column alignment override — wins over the DataTables class set via getColumnClassName.
+        if (aStyle.align && aStyle.align !== ColumnAlignment.DEFAULT) {
+          $(cell).css('text-align', aStyle.align);
+        }
       },
     };
     //let ignoreNullValues = this.getColumnIgnoreNullValue(i);
@@ -340,7 +346,11 @@ export const BuildColumnDefs = (
   return columnDefs;
 };
 
-const getColumnClassName = (alignNumbersToRightEnabled: boolean, columnType: string) => {
+const getColumnClassName = (
+  alignNumbersToRightEnabled: boolean,
+  alignStringsToRightEnabled: boolean,
+  columnType: string,
+) => {
   let columnClassName = '';
 
   // column type "date" is very limited, and overrides our formatting
@@ -352,7 +362,7 @@ const getColumnClassName = (alignNumbersToRightEnabled: boolean, columnType: str
   if (columnType === 'number' && alignNumbersToRightEnabled) {
     columnClassName = 'dt-right'; // any reason not to align numbers right?
   }
-  if (columnType === 'string') {
+  if (columnType === 'string' && alignStringsToRightEnabled) {
     columnClassName = 'dt-right';
   }
   return columnClassName;

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -356,7 +356,7 @@ export const BuildColumnDefs = (
   return columnDefs;
 };
 
-const getColumnClassName = (alignment: AlignmentFlags, columnType: string) => {
+export const getColumnClassName = (alignment: AlignmentFlags, columnType: string) => {
   let columnClassName = '';
 
   // column type "date" is very limited, and overrides our formatting

--- a/src/migrations.test.ts
+++ b/src/migrations.test.ts
@@ -4,7 +4,7 @@ import {
   DatatablePanelMigrationHandler,
   migrateDefaults,
 } from './migrations';
-import { ColumnAlignment } from 'components/options/columnstyles/types';
+import { ColumnAlignment } from 'types';
 
 describe('Datatable -> DatatableV2 migrations', () => {
   it('only migrates old datatable', () => {

--- a/src/migrations.test.ts
+++ b/src/migrations.test.ts
@@ -5,8 +5,7 @@ import {
   DatatablePanelMigrationHandler,
   migrateDefaults,
 } from './migrations';
-import { ColumnAlignment } from 'types';
-import type { DatatableOptions } from 'types';
+import { ColumnAlignment, type DatatableOptions } from 'types';
 
 describe('Datatable -> DatatableV2 migrations', () => {
   it('only migrates old datatable', () => {

--- a/src/migrations.test.ts
+++ b/src/migrations.test.ts
@@ -1,10 +1,12 @@
 import { PanelModel } from '@grafana/data';
 
 import {
+  applyOptionDefaults,
   DatatablePanelMigrationHandler,
   migrateDefaults,
 } from './migrations';
 import { ColumnAlignment } from 'types';
+import type { DatatableOptions } from 'types';
 
 describe('Datatable -> DatatableV2 migrations', () => {
   it('only migrates old datatable', () => {
@@ -38,5 +40,39 @@ describe('Datatable -> DatatableV2 migrations', () => {
     });
     expect(options.columnStylesConfig).toHaveLength(1);
     expect(options.columnStylesConfig[0].align).toBe(ColumnAlignment.DEFAULT);
+  });
+
+  it('applyOptionDefaults patches alignStringsToRightEnabled=true when missing', () => {
+    const options = { columnStylesConfig: [] } as unknown as DatatableOptions;
+    const patched = applyOptionDefaults(options);
+    expect(patched.alignStringsToRightEnabled).toBe(true);
+  });
+
+  it('applyOptionDefaults preserves an explicit alignStringsToRightEnabled=false', () => {
+    const options = {
+      alignStringsToRightEnabled: false,
+      columnStylesConfig: [],
+    } as unknown as DatatableOptions;
+    const patched = applyOptionDefaults(options);
+    expect(patched.alignStringsToRightEnabled).toBe(false);
+  });
+
+  it('applyOptionDefaults stamps align=DEFAULT on column styles that are missing it', () => {
+    const options = {
+      alignStringsToRightEnabled: true,
+      columnStylesConfig: [{ label: 'existing' }, { label: 'keeps-align', align: ColumnAlignment.LEFT }],
+    } as unknown as DatatableOptions;
+    const patched = applyOptionDefaults(options);
+    expect(patched.columnStylesConfig[0].align).toBe(ColumnAlignment.DEFAULT);
+    expect(patched.columnStylesConfig[1].align).toBe(ColumnAlignment.LEFT);
+  });
+
+  it('DatatablePanelMigrationHandler patches React-saved panels via applyOptionDefaults', () => {
+    const panel = {
+      options: { columnStylesConfig: [{ label: 'existing' }] },
+    } as unknown as PanelModel;
+    const migrated = DatatablePanelMigrationHandler(panel) as DatatableOptions;
+    expect(migrated.alignStringsToRightEnabled).toBe(true);
+    expect(migrated.columnStylesConfig[0].align).toBe(ColumnAlignment.DEFAULT);
   });
 });

--- a/src/migrations.test.ts
+++ b/src/migrations.test.ts
@@ -2,7 +2,9 @@ import { PanelModel } from '@grafana/data';
 
 import {
   DatatablePanelMigrationHandler,
+  migrateDefaults,
 } from './migrations';
+import { ColumnAlignment } from 'components/options/columnstyles/types';
 
 describe('Datatable -> DatatableV2 migrations', () => {
   it('only migrates old datatable', () => {
@@ -18,4 +20,23 @@ describe('Datatable -> DatatableV2 migrations', () => {
     expect(options).toMatchSnapshot();
   });
 
+  it('migrateDefaults seeds alignStringsToRightEnabled=true so string columns stay right-aligned', () => {
+    const options = migrateDefaults({});
+    expect(options.alignStringsToRightEnabled).toBe(true);
+  });
+
+  it('migrateDefaults seeds migrated column styles with align=DEFAULT', () => {
+    const options = migrateDefaults({
+      styles: [
+        {
+          pattern: 'A-series',
+          type: 'number',
+          colors: [],
+          thresholds: [],
+        },
+      ],
+    });
+    expect(options.columnStylesConfig).toHaveLength(1);
+    expect(options.columnStylesConfig[0].align).toBe(ColumnAlignment.DEFAULT);
+  });
 });

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -7,6 +7,7 @@ import {
 
 import {
   AggregationOptions,
+  ColumnAlignment,
   ColumnAliasField,
   ColumnSorting,
   ColumnSortingOptions,
@@ -16,7 +17,7 @@ import {
   TransformationOptions,
 } from './types';
 import { Threshold } from 'components/options/thresholds/types';
-import { ColumnAlignment, ColumnStyleDate, ColumnStyleHidden, ColumnStyleItemType, ColumnStyleMetric, ColumnStyles, ColumnStyleString } from 'components/options/columnstyles/types';
+import { ColumnStyleDate, ColumnStyleHidden, ColumnStyleItemType, ColumnStyleMetric, ColumnStyles, ColumnStyleString } from 'components/options/columnstyles/types';
 //import { DEFAULT_CRITICAL_COLOR_RGBA, DEFAULT_OK_COLOR_RGBA, DEFAULT_WARNING_COLOR_RGBA } from 'components/options/defaults';
 
 interface AngularDatatableOptions {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -67,6 +67,9 @@ export const DatatablePanelMigrationHandler = (panel: PanelModel<DatatableOption
       // This happens on the first load or when migrating from angular
       return {} as any;
     }
+    // When adding a new field to DatatableOptions or ColumnStyleItemType,
+    // extend applyOptionDefaults so existing React-saved panels pick up a
+    // sensible default instead of loading with undefined.
     return applyOptionDefaults(panel.options);
   }
   //

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -67,8 +67,7 @@ export const DatatablePanelMigrationHandler = (panel: PanelModel<DatatableOption
       // This happens on the first load or when migrating from angular
       return {} as any;
     }
-    // have settings, return them unchanged
-    return panel.options;
+    return applyOptionDefaults(panel.options);
   }
   //
   // mapping are inside styles, there are no global mappings
@@ -88,6 +87,24 @@ export const DatatablePanelMigrationHandler = (panel: PanelModel<DatatableOption
   return options;
 };
 
+
+// Patches fields that were added to DatatableOptions after existing panels were
+// saved. The panel-options registry only applies defaultValue for freshly-created
+// panels, so without this, existing React-saved panels would read undefined for
+// new fields and display stale UI state (e.g. a "Right Align Text" switch that
+// looks off while the panel is still right-aligning at runtime).
+export const applyOptionDefaults = (options: DatatableOptions): DatatableOptions => {
+  const patched = { ...options };
+  if (patched.alignStringsToRightEnabled === undefined) {
+    patched.alignStringsToRightEnabled = true;
+  }
+  if (patched.columnStylesConfig) {
+    patched.columnStylesConfig = patched.columnStylesConfig.map((style) =>
+      style.align === undefined ? { ...style, align: ColumnAlignment.DEFAULT } : style,
+    );
+  }
+  return patched;
+};
 
 export const migrateDefaults = (angular: AngularDatatableOptions) => {
   let options: DatatableOptions = {

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -16,7 +16,7 @@ import {
   TransformationOptions,
 } from './types';
 import { Threshold } from 'components/options/thresholds/types';
-import { ColumnStyleDate, ColumnStyleHidden, ColumnStyleItemType, ColumnStyleMetric, ColumnStyles, ColumnStyleString } from 'components/options/columnstyles/types';
+import { ColumnAlignment, ColumnStyleDate, ColumnStyleHidden, ColumnStyleItemType, ColumnStyleMetric, ColumnStyles, ColumnStyleString } from 'components/options/columnstyles/types';
 //import { DEFAULT_CRITICAL_COLOR_RGBA, DEFAULT_OK_COLOR_RGBA, DEFAULT_WARNING_COLOR_RGBA } from 'components/options/defaults';
 
 interface AngularDatatableOptions {
@@ -91,6 +91,7 @@ export const DatatablePanelMigrationHandler = (panel: PanelModel<DatatableOption
 export const migrateDefaults = (angular: AngularDatatableOptions) => {
   let options: DatatableOptions = {
     alignNumbersToRightEnabled: false,
+    alignStringsToRightEnabled: true,
     columnAliases: [],
     columnFiltersEnabled: false,
     columnWidthHints: [],
@@ -349,6 +350,7 @@ const migrateStyles = (styles: any[]): ColumnStyleItemType[] => {
       label: `Migrated-Style-${index}`,
       nameOrRegex: element.pattern,
       order: index,
+      align: ColumnAlignment.DEFAULT,
       activeStyle: migrateItemType(element.type),
       dateStyle: {
         dateFormat: element.dateFormat,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { ColumnStyleItemType } from "components/options/columnstyles/types";
 
 export interface DatatableOptions {
   alignNumbersToRightEnabled: boolean;
+  alignStringsToRightEnabled: boolean;
   columnAliases: ColumnAliasField[];
   columnFiltersEnabled: boolean,
   columnWidthHints: ColumnWidthHint[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,20 @@ export const ColorModeOptions = [
   { label: 'Row Column', value: ColumnStyleColoring.RowColumn },
 ];
 
+export enum ColumnAlignment {
+  DEFAULT = 'default',
+  LEFT = 'left',
+  CENTER = 'center',
+  RIGHT = 'right',
+};
+
+export const ColumnAlignmentOptions = [
+  { label: 'Default', value: ColumnAlignment.DEFAULT },
+  { label: 'Left', value: ColumnAlignment.LEFT },
+  { label: 'Center', value: ColumnAlignment.CENTER },
+  { label: 'Right', value: ColumnAlignment.RIGHT },
+];
+
 export type ColumnStyling = {
   nameOrRegex: string;
   type: ColumnStyleType;

--- a/tests/phase3-panel/text-alignment-panel-level.spec.ts
+++ b/tests/phase3-panel/text-alignment-panel-level.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+// Datatable-TextAlignmentPanelLevel.json configures:
+//   - alignNumbersToRightEnabled: true  (Value column should keep dt-right)
+//   - alignStringsToRightEnabled: false (Name column should NOT get dt-right)
+//   - no per-column overrides
+// CSV: Name,Value → Name is a string column, Value is a number column.
+// This proves the panel-level toggle gates the class-level alignment;
+// without the fix, the Name column would carry dt-right unconditionally.
+test('alignStringsToRightEnabled=false leaves string columns without dt-right', async ({
+  readProvisionedDashboard,
+  gotoDashboardPage,
+  page,
+}) => {
+  const dashboard = await test.step('load provisioned dashboard', async () => {
+    return readProvisionedDashboard({
+      fileName: 'dashboards/Datatable-TextAlignmentPanelLevel.json',
+    });
+  });
+
+  await test.step('open dashboard', async () => {
+    await gotoDashboardPage({ uid: dashboard.uid });
+  });
+
+  await test.step('wait for datatable to render', async () => {
+    await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
+  });
+
+  await test.step('Name column cells (1st column) do not carry dt-right', async () => {
+    // Name is the first column. dt-right is what makes text right-align at the
+    // class level; with alignStringsToRightEnabled=false it must be absent.
+    await expect(page.locator('table tbody tr').first().locator('td').first()).not.toHaveClass(/\bdt-right\b/);
+  });
+
+  await test.step('Value column cells (2nd column) still carry dt-right', async () => {
+    // alignNumbersToRightEnabled is still true, so the numeric column should
+    // retain the class. Acts as a positive control for the previous step.
+    await expect(page.locator('table tbody tr').first().locator('td').nth(1)).toHaveClass(/\bdt-right\b/);
+  });
+});

--- a/tests/phase3-panel/text-alignment.spec.ts
+++ b/tests/phase3-panel/text-alignment.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+// Datatable-TextAlignment.json configures the A-series column with a column
+// style whose align='left'. getColumnClassName would otherwise give numeric
+// columns `dt-right` (the panel-level alignNumbersToRightEnabled is still
+// true), so an inline `text-align: left` on those cells proves the per-column
+// override took effect.
+test('per-column align override paints inline text-align on matching cells', async ({
+  readProvisionedDashboard,
+  gotoDashboardPage,
+  page,
+}) => {
+  const dashboard = await test.step('load provisioned dashboard', async () => {
+    return readProvisionedDashboard({
+      fileName: 'dashboards/Datatable-TextAlignment.json',
+    });
+  });
+
+  await test.step('open dashboard', async () => {
+    await gotoDashboardPage({ uid: dashboard.uid });
+  });
+
+  await test.step('wait for datatable to render', async () => {
+    await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
+  });
+
+  await test.step('at least one cell carries inline text-align:left', async () => {
+    await expect
+      .poll(() => page.locator('table tbody td[style*="text-align: left"]').count(), {
+        timeout: 10000,
+        message: 'expected at least one A-series cell to carry text-align:left inline',
+      })
+      .toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #282.

String columns were hard-coded to right-align with no user-visible setting. This PR adds two orthogonal controls (panel-level default + per-column override), wires them safely through the existing options schema, and hardens the boundary where alignment values flow into the DOM.

## Added

- **Panel-level `Right Align Text` toggle** — new `alignStringsToRightEnabled` option (default `true`) next to the existing `Right Align Numbers` switch. Disabling it lets string columns inherit the DataTables default (left-aligned).
- **Per-column `Cell Alignment` Select** on every column style — `ColumnStyleItemType.align` with values `default | left | center | right`. Paints an inline `text-align` on each matching cell when set to a non-`default` value, so the override wins over the class-level alignment. Applies to any `activeStyle` (metric / string / date).

## Refactoring

- Move `ColumnAlignment` / `ColumnAlignmentOptions` from `src/components/options/columnstyles/types.ts` into `src/types.ts` alongside the other global option enums (`ColumnStyleColoring`, `DatatablePagingType`, `AggregationType`).
- Collapse two adjacent positional booleans on `getColumnClassName`, `BuildColumnDefs`, and `ConvertDataFrameToDataTableFormat` into a single `AlignmentFlags = { numbers, strings }` struct. A transposed call site is now a type error rather than a silent swap.

## Fixes (migration + hardening)

- **Migration for existing React-saved panels.** `DatatablePanelMigrationHandler`'s non-Angular branch previously returned `panel.options` unchanged, so panels saved before this PR would load with `alignStringsToRightEnabled=undefined` and render the options-editor Switch in an "off" state while the panel itself was still right-aligning. A new `applyOptionDefaults` helper patches the flag to `true` when missing and stamps `align='default'` on every column style that lacks it. The helper is the documented hook for any future field added to `DatatableOptions` or `ColumnStyleItemType`.
- **Defense-in-depth against untrusted alignment values.** `createdCell` now whitelists `aStyle.align` against `ColumnAlignmentOptions` before passing it to jQuery's `.css('text-align', ...)`. The value is typed but not runtime-validated, so a hand-crafted panel JSON could otherwise feed an arbitrary string into the DOM style API. Browsers reject invalid `text-align` values, so there's no known exploit — this hardens the boundary anyway.

## Testing

- **Unit (51 tests, 4 new suites covered):**
  - `migrations.test.ts` — Angular-path `migrateDefaults` seeds `alignStringsToRightEnabled=true` and stamps `align='default'` on migrated styles; React-path `applyOptionDefaults` patches missing flag, preserves explicit `false`, stamps missing `align`, and the end-to-end handler flow.
  - `ColumnStyleItem.test.tsx` — the Cell Alignment Select emits the chosen value through the shared `setter`.
  - `ColumnStylesEditor.test.tsx` — `addItem` stamps `align='default'` on newly-added trackers.
- **E2E:**
  - New provisioned dashboard `provisioning/dashboards/dashboards/Datatable-TextAlignment.json`.
  - New spec `tests/phase3-panel/text-alignment.spec.ts` — asserts an inline `text-align: left` on cells whose column style sets `align='left'` (the panel-level `alignNumbersToRightEnabled` is still `true`, so the inline style only appears when the per-column override kicks in).

## Verification

- `pnpm typecheck` — clean
- `pnpm exec eslint --ext .ts,.tsx src` — 0 errors (pre-existing `Select` / `collapsible` deprecation warnings only)
- `pnpm exec jest` — 9 suites, 51 tests pass
- `pnpm e2e tests/phase3-panel/` — 4 specs pass against a locally-built plugin on Grafana 12.2.0
- `pnpm lint:md` — 5 files, 0 errors

## Test plan

- [x] CI runs green on the full e2e matrix
- [x] Local smoke: new **Right Align Text** toggle appears under Visual Options and flips string-column alignment on change
- [x] Local smoke: each column style exposes a **Cell Alignment** Select; setting it to `Left` paints `text-align: left` on the matching column's cells
- [x] Local smoke: an existing pre-#282 dashboard still right-aligns its string columns on first load (migration patches undefined to `true`)
- [x] Existing `Datatable-RandomWalk-CustomThresholds` dashboard still renders colored cells (no regression from the `createdCell` changes)
