### PR TITLE
fix(filter): column-filter row alignment (closes #278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,21 +166,34 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 
-- **Column-filter row no longer misaligns columns** (closes #278). Enabling
-  "Filter by column" previously injected a filter row after DataTables had
-  already cached column widths and stripped all layout classes from the
-  cloned cells, pushing content outside its column. The injection now runs
-  inside DataTables' `initComplete`, preserves `dt-*` layout classes (only
-  sort-interactivity classes are stripped), adds `columns.adjust()` to
-  resync the scrollX header clone, debounces the search handler at 250 ms,
-  stops click propagation so the filter row cannot trigger a header sort,
-  and guards against duplicate filter rows on re-init. A themed CSS block
-  sizes each input to `width: 100%` with `box-sizing: border-box` so the
-  input never exceeds its cell, covering the root-cause spill symptom. A
-  new Playwright spec
-  (`tests/phase3-panel/column-filter-alignment.spec.ts`) pins the alignment
-  invariant against the DataTables v2 `dt-scroll-head` / `dt-scroll-body`
-  DOM.
+- **Column-filter row no longer misaligns columns, and typing now actually
+  filters** (closes #278). Enabling "Filter by column" previously injected
+  a filter row after DataTables had already cached column widths and
+  stripped all layout classes from the cloned cells, pushing content
+  outside its column. The injection now runs inside DataTables'
+  `initComplete`, preserves `dt-*` layout classes (only sort-interactivity
+  classes are stripped), adds `columns.adjust()` to resync the scrollX
+  header clone, debounces the search handler at 250 ms, and guards against
+  duplicate filter rows on re-init. A themed CSS block sizes each input to
+  `width: 100%` with `box-sizing: border-box` so the input never exceeds
+  its cell. Input handlers are bound via jQuery event delegation on the
+  table container so they survive the per-draw header-clone refresh that
+  DataTables does in scrollX mode — without this, the visible inputs
+  (which live in the `.dt-scroll-head` clone) carried no listeners and
+  typing was a no-op. Click propagation is stopped on the filter row so a
+  filter click can't trigger a header sort. DataTables' `searching`
+  feature is now enabled whenever `columnFiltersEnabled` is on (previously
+  a user with `searchEnabled=false` had `searching=false`, which made
+  `api.column(i).search()` a no-op — the visible fields accepted text but
+  nothing filtered); `layout: { topEnd: null }` suppresses the stray
+  global search control so no unwanted search box appears. Per-column
+  filtering is also now WYSIWYG: the `render` callback returns
+  `valueFormatted` for DataTables' `filter` orthogonal data instead of
+  `valueRaw`, so typing the displayed string (e.g. `5.00`, not the raw
+  `5`) matches. A new Playwright spec
+  (`tests/phase3-panel/column-filter-alignment.spec.ts`) pins the
+  alignment invariant and filter-row interactivity against the DataTables
+  v2 `dt-scroll-head` / `dt-scroll-body` DOM.
 - Remove `transparent={false}` from `Switch` usages in `ColumnStyleItem.tsx`
   (prop moved to `InlineSwitch` only; all sites relied on the default)
 - Fix `tests/phase2-installed/check-installed.spec.ts` strict-mode locator collision on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,10 +190,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   filtering is also now WYSIWYG: the `render` callback returns
   `valueFormatted` for DataTables' `filter` orthogonal data instead of
   `valueRaw`, so typing the displayed string (e.g. `5.00`, not the raw
-  `5`) matches. A new Playwright spec
-  (`tests/phase3-panel/column-filter-alignment.spec.ts`) pins the
+  `5`) matches. Two Playwright specs pin the fix:
+  `tests/phase3-panel/column-filter-alignment.spec.ts` covers the
   alignment invariant and filter-row interactivity against the DataTables
-  v2 `dt-scroll-head` / `dt-scroll-body` DOM.
+  v2 `dt-scroll-head` / `dt-scroll-body` DOM, and
+  `tests/phase3-panel/column-filter-many-columns.spec.ts` exercises a
+  nine-column provisioned dashboard end-to-end — including real user
+  keystrokes that fire the delegated handler. Additional hardening from
+  code review: delegated `.columnFilter` handlers are now explicitly
+  detached before `destroy()` so a container-reuse teardown path cannot
+  accumulate stale listeners across re-inits; filter `<input>` elements
+  are built via `document.createElement` rather than `$th.html(template)`
+  so a column title containing a `"` cannot break out of the placeholder
+  attribute (`textUtil.sanitize` strips tags but does not escape
+  attribute-context quotes); and `setDataTableReady(true)` inside
+  `initComplete` is now gated on a `mountedRef` so the async callback
+  cannot setState on an unmounted component.
 - **First-paint no longer flashes un-formatted data.** The panel previously
   rendered the `<table>` node as soon as the transformed rows were cached
   but before DataTables had initialized, so users saw a brief flash of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   is the end-to-end proof of issue #282 itself: the panel-level
   switch disables class-level right-alignment on string columns.
 
+### Fixed
+
+- **Column-filter row no longer misaligns columns** (closes #278). Enabling
+  "Filter by column" previously injected a filter row after DataTables had
+  already cached column widths and stripped all layout classes from the
+  cloned cells, pushing content outside its column. The injection now runs
+  inside DataTables' `initComplete`, preserves `dt-*` layout classes (only
+  sort-interactivity classes are stripped), adds `columns.adjust()` to
+  resync the scrollX header clone, debounces the search handler at 250 ms,
+  stops click propagation so the filter row cannot trigger a header sort,
+  and guards against duplicate filter rows on re-init. A themed CSS block
+  sizes each input to `width: 100%` with `box-sizing: border-box` so the
+  input never exceeds its cell, covering the root-cause spill symptom. A
+  new Playwright spec
+  (`tests/phase3-panel/column-filter-alignment.spec.ts`) pins the alignment
+  invariant against the DataTables v2 `dt-scroll-head` / `dt-scroll-body`
+  DOM.
+
 ## [2.0.2] - 2025-05-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 
+- **Column-filter row no longer misaligns columns** (closes #278). Enabling
+  "Filter by column" previously injected a filter row after DataTables had
+  already cached column widths and stripped all layout classes from the
+  cloned cells, pushing content outside its column. The injection now runs
+  inside DataTables' `initComplete`, preserves `dt-*` layout classes (only
+  sort-interactivity classes are stripped), adds `columns.adjust()` to
+  resync the scrollX header clone, debounces the search handler at 250 ms,
+  stops click propagation so the filter row cannot trigger a header sort,
+  and guards against duplicate filter rows on re-init. A themed CSS block
+  sizes each input to `width: 100%` with `box-sizing: border-box` so the
+  input never exceeds its cell, covering the root-cause spill symptom. A
+  new Playwright spec
+  (`tests/phase3-panel/column-filter-alignment.spec.ts`) pins the alignment
+  invariant against the DataTables v2 `dt-scroll-head` / `dt-scroll-body`
+  DOM.
 - Remove `transparent={false}` from `Switch` usages in `ColumnStyleItem.tsx`
   (prop moved to `InlineSwitch` only; all sites relied on the default)
 - Fix `tests/phase2-installed/check-installed.spec.ts` strict-mode locator collision on
@@ -248,24 +263,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   do NOT carry `dt-right` while the Value column cells still do. This
   is the end-to-end proof of issue #282 itself: the panel-level
   switch disables class-level right-alignment on string columns.
-
-### Fixed
-
-- **Column-filter row no longer misaligns columns** (closes #278). Enabling
-  "Filter by column" previously injected a filter row after DataTables had
-  already cached column widths and stripped all layout classes from the
-  cloned cells, pushing content outside its column. The injection now runs
-  inside DataTables' `initComplete`, preserves `dt-*` layout classes (only
-  sort-interactivity classes are stripped), adds `columns.adjust()` to
-  resync the scrollX header clone, debounces the search handler at 250 ms,
-  stops click propagation so the filter row cannot trigger a header sort,
-  and guards against duplicate filter rows on re-init. A themed CSS block
-  sizes each input to `width: 100%` with `box-sizing: border-box` so the
-  input never exceeds its cell, covering the root-cause spill symptom. A
-  new Playwright spec
-  (`tests/phase3-panel/column-filter-alignment.spec.ts`) pins the alignment
-  invariant against the DataTables v2 `dt-scroll-head` / `dt-scroll-body`
-  DOM.
 
 ## [2.0.2] - 2025-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   (`tests/phase3-panel/column-filter-alignment.spec.ts`) pins the
   alignment invariant and filter-row interactivity against the DataTables
   v2 `dt-scroll-head` / `dt-scroll-body` DOM.
+- **First-paint no longer flashes un-formatted data.** The panel previously
+  rendered the `<table>` node as soon as the transformed rows were cached
+  but before DataTables had initialized, so users saw a brief flash of the
+  raw table (no formatters, no threshold coloring, no filter row) before it
+  settled. A `dataTableReady` state now stays `false` until DataTables'
+  `initComplete` fires; a themed loading overlay covers the wrapper and
+  the `<table>` is rendered with `visibility: hidden` until then. The
+  overlay also re-hides the table on every re-init triggered by an options
+  change, so transient draws between `destroy` and the next `initComplete`
+  don't leak through either.
 - Remove `transparent={false}` from `Switch` usages in `ColumnStyleItem.tsx`
   (prop moved to `InlineSwitch` only; all sites relied on the default)
 - Fix `tests/phase2-installed/check-installed.spec.ts` strict-mode locator collision on

--- a/provisioning/dashboards/dashboards/Datatable-ColumnFilter-ManyColumns.json
+++ b/provisioning/dashboards/dashboards/Datatable-ColumnFilter-ManyColumns.json
@@ -1,0 +1,198 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 9,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource",
+        "uid": "P53465F745837BCFD"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "alignNumbersToRightEnabled": true,
+        "alignStringsToRightEnabled": true,
+        "columnAliases": [],
+        "columnFiltersEnabled": true,
+        "columnSorting": [
+          {
+            "index": 0,
+            "order": "asc"
+          }
+        ],
+        "columnStylesConfig": [
+          {
+            "activeStyle": "metric",
+            "align": "left",
+            "dateStyle": {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss"
+            },
+            "enabled": true,
+            "hiddenStyle": {},
+            "label": "A-series-left",
+            "metricStyle": {
+              "alias": "",
+              "colorMode": "disabled",
+              "colors": [
+                "#299c46",
+                "#ed8128",
+                "#f53636",
+                "#0a55a1"
+              ],
+              "decimals": "2",
+              "ignoreNullValues": true,
+              "thresholds": [],
+              "unitFormat": "short"
+            },
+            "nameOrRegex": "A-series",
+            "order": 0,
+            "stringStyle": {
+              "clickThrough": "",
+              "clickThroughCustomTarget": "",
+              "clickThroughCustomTargetEnabled": false,
+              "clickThroughOpenNewTab": true,
+              "clickThroughSanitize": true,
+              "splitByPattern": ""
+            }
+          }
+        ],
+        "columnWidthHints": [],
+        "columns": [],
+        "compactRowsEnabled": false,
+        "datatablePagingType": "simple_numbers",
+        "emptyDataEnabled": true,
+        "emptyDataText": "",
+        "fontSizePercent": "100%",
+        "hoverEnabled": true,
+        "infoEnabled": true,
+        "lengthChangeEnabled": true,
+        "orderColumnEnabled": false,
+        "rowNumbersEnabled": false,
+        "rowsPerPage": 5,
+        "scroll": true,
+        "searchEnabled": false,
+        "searchHighlightingEnabled": false,
+        "stripedRowsEnabled": true,
+        "transformation": "timeseries-to-columns",
+        "transformationAggregations": [
+          "last"
+        ],
+        "wrapToFitEnabled": true
+      },
+      "pluginVersion": "2.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 30,
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "spread": 12,
+          "startValue": 5
+        },
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 40,
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "spread": 10,
+          "startValue": 10
+        },
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 50,
+          "refId": "C",
+          "scenarioId": "random_walk",
+          "spread": 8,
+          "startValue": 15
+        },
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 60,
+          "refId": "D",
+          "scenarioId": "random_walk",
+          "spread": 6,
+          "startValue": 20
+        },
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 70,
+          "refId": "E",
+          "scenarioId": "random_walk",
+          "spread": 5,
+          "startValue": 25
+        },
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 80,
+          "refId": "F",
+          "scenarioId": "random_walk",
+          "spread": 4,
+          "startValue": 30
+        },
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 90,
+          "refId": "G",
+          "scenarioId": "random_walk",
+          "spread": 3,
+          "startValue": 35
+        },
+        {
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "P53465F745837BCFD" },
+          "max": 100,
+          "refId": "H",
+          "scenarioId": "random_walk",
+          "spread": 3,
+          "startValue": 40
+        }
+      ],
+      "title": "Column Filter — Many Columns",
+      "type": "briangann-datatable-panel"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Datatable Column Filter — Many Columns",
+  "uid": "datatable-column-filter-many",
+  "version": 1
+}

--- a/provisioning/dashboards/dashboards/Datatable-ColumnFilter.json
+++ b/provisioning/dashboards/dashboards/Datatable-ColumnFilter.json
@@ -1,0 +1,145 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 8,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource",
+        "uid": "P53465F745837BCFD"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "alignNumbersToRightEnabled": true,
+        "alignStringsToRightEnabled": true,
+        "columnAliases": [],
+        "columnFiltersEnabled": true,
+        "columnSorting": [
+          {
+            "index": 0,
+            "order": "asc"
+          }
+        ],
+        "columnStylesConfig": [
+          {
+            "activeStyle": "metric",
+            "align": "left",
+            "dateStyle": {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss"
+            },
+            "enabled": true,
+            "hiddenStyle": {},
+            "label": "A-series-left",
+            "metricStyle": {
+              "alias": "",
+              "colorMode": "disabled",
+              "colors": [
+                "#299c46",
+                "#ed8128",
+                "#f53636",
+                "#0a55a1"
+              ],
+              "decimals": "2",
+              "ignoreNullValues": true,
+              "thresholds": [],
+              "unitFormat": "short"
+            },
+            "nameOrRegex": "A-series",
+            "order": 0,
+            "stringStyle": {
+              "clickThrough": "",
+              "clickThroughCustomTarget": "",
+              "clickThroughCustomTargetEnabled": false,
+              "clickThroughOpenNewTab": true,
+              "clickThroughSanitize": true,
+              "splitByPattern": ""
+            }
+          }
+        ],
+        "columnWidthHints": [],
+        "columns": [],
+        "compactRowsEnabled": false,
+        "datatablePagingType": "simple_numbers",
+        "emptyDataEnabled": true,
+        "emptyDataText": "",
+        "fontSizePercent": "100%",
+        "hoverEnabled": true,
+        "infoEnabled": true,
+        "lengthChangeEnabled": true,
+        "orderColumnEnabled": false,
+        "rowNumbersEnabled": false,
+        "rowsPerPage": 5,
+        "scroll": true,
+        "searchEnabled": false,
+        "searchHighlightingEnabled": false,
+        "stripedRowsEnabled": true,
+        "transformation": "timeseries-to-columns",
+        "transformationAggregations": [
+          "last"
+        ],
+        "wrapToFitEnabled": true
+      },
+      "pluginVersion": "2.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "P53465F745837BCFD"
+          },
+          "max": 30,
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "spread": 12,
+          "startValue": 5
+        }
+      ],
+      "title": "Column Filter",
+      "type": "briangann-datatable-panel"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Datatable Column Filter",
+  "uid": "datatable-column-filter",
+  "version": 1
+}

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -43,6 +43,10 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
   const [dataTableClassesEnabled, setDatatableClassesEnabled] = useState<string[]>([]);
   const [cachedProcessedData, setCachedProcessedData] = useState<DTData>();
   const [cachedColumnDefs, setCachedColumnDefs] = useState<ConfigColumnDefs[]>();
+  // Gates the table visibility. Flipped to true inside DataTables'
+  // `initComplete` once formatters, threshold coloring, and the optional
+  // filter row are all in place. Hides the un-formatted first-paint flash.
+  const [dataTableReady, setDataTableReady] = useState(false);
 
   const divStyles = useStyles2(datatableThemedStyles);
   const dataTableDOMRef = useRef<HTMLTableElement>(null);
@@ -238,6 +242,10 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
 
   useEffect(() => {
     if (cachedProcessedData !== undefined && cachedColumnDefs !== undefined) {
+      // Re-init in progress — keep the overlay up until the new initComplete
+      // fires, otherwise a transient un-formatted paint appears between
+      // destroy and the next draw.
+      setDataTableReady(false);
 
       // 32 = panel title when displayed
       // 8 = panel content wrapper padding (all the way around) - need this for width too!
@@ -318,6 +326,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
               if (props.options.columnFiltersEnabled) {
                 enableColumnFilters(this.api());
               }
+              setDataTableReady(true);
             },
           };
           if (props.options.rowsPerPage) {
@@ -354,21 +363,38 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     props.options.transformation,
   ]);
 
-  if (cachedProcessedData === undefined || cachedColumnDefs === undefined) {
-    return (
-      <>Loading... please wait</>
-    )
-  }
+  const hasData = cachedProcessedData !== undefined && cachedColumnDefs !== undefined;
   return (
-    <div id={dataTableWrapperId} className={divStyles} style={{ width: '100%', height: '100%' }}>
-      {props.data &&
-        <table style={{ width: '100%' }}
+    <div
+      id={dataTableWrapperId}
+      className={divStyles}
+      style={{ width: '100%', height: '100%', position: 'relative' }}
+    >
+      {!dataTableReady && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1,
+            background: theme2.colors.background.primary,
+            color: theme2.colors.text.secondary,
+          }}
+        >
+          Loading... please wait
+        </div>
+      )}
+      {hasData && props.data && (
+        <table
+          style={{ width: '100%', visibility: dataTableReady ? 'visible' : 'hidden' }}
           id={dataTableId}
           ref={dataTableDOMRef}
           className={dataTableClassesEnabled.join(' ')}
-          width="100%">
-        </table>
-      }
+          width="100%"
+        />
+      )}
     </div>
   );
 };

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -98,10 +98,19 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     // go on the wrapper via delegation below, because DataTables' scrollX
     // mode re-clones the source thead into `.dt-scroll-head` on every draw
     // and wipes any listeners bound directly to input nodes.
+    // Build the <input> via DOM APIs rather than `.html(string)` templating
+    // so a column title containing a `"` character cannot break out of the
+    // placeholder attribute — `textUtil.sanitize` strips HTML tags but does
+    // not escape attribute-context quotes.
     $header.find(`tr.column-filter th`).each(function () {
-      const $th = $(this);
-      const title = textUtil.sanitize($th.text());
-      $th.html('<input class="column-filter" type="text" placeholder="Search ' + title + '" />');
+      const th = this as HTMLTableCellElement;
+      const title = textUtil.sanitize(th.textContent ?? '');
+      const input = document.createElement('input');
+      input.className = 'column-filter';
+      input.type = 'text';
+      input.placeholder = `Search ${title}`;
+      th.textContent = '';
+      th.appendChild(input);
     });
 
     // Delegated handlers on the table container survive DataTables' per-draw
@@ -265,7 +274,11 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
       }
       if (dataTableDOMRef.current && cachedProcessedData.Columns.length > 0) {
         try {
-          // cleanup existing table, columns may have changed
+          // cleanup existing table, columns may have changed. Remove any
+          // delegated `.columnFilter` handlers first so a destroy path that
+          // retains the container element cannot accumulate stale handlers
+          // across re-inits.
+          $(dataTableDOMRef.current).closest('.dt-container').off('.columnFilter');
           const aDT = $(dataTableDOMRef.current).DataTable();
           aDT.destroy();
           $(dataTableDOMRef.current).empty();

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -50,6 +50,15 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
 
   const divStyles = useStyles2(datatableThemedStyles);
   const dataTableDOMRef = useRef<HTMLTableElement>(null);
+  // Tracks whether the component is still mounted, so DataTables' async
+  // `initComplete` callback doesn't setState on an unmounted instance.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const dataTableWrapperId = `data-table-wrapper-${props.id}`;
   const dataTableId = `data-table-renderer-${props.id}`;
@@ -339,7 +348,9 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
               if (props.options.columnFiltersEnabled) {
                 enableColumnFilters(this.api());
               }
-              setDataTableReady(true);
+              if (mountedRef.current) {
+                setDataTableReady(true);
+              }
             },
           };
           if (props.options.rowsPerPage) {

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -90,28 +90,41 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
       .addClass('column-filter');
     newHeaders.appendTo(header as Element);
 
-    // Populate each cloned th with a search input. Clicks on the filter row
-    // must not bubble up to DataTables' header sort handler.
-    $header.find(`tr.column-filter th`).each(function (i) {
+    // Populate each cloned th with a search input. Structure only — handlers
+    // go on the wrapper via delegation below, because DataTables' scrollX
+    // mode re-clones the source thead into `.dt-scroll-head` on every draw
+    // and wipes any listeners bound directly to input nodes.
+    $header.find(`tr.column-filter th`).each(function () {
       const $th = $(this);
       const title = textUtil.sanitize($th.text());
       $th.html('<input class="column-filter" type="text" placeholder="Search ' + title + '" />');
-      $th.on('click', function (ev) {
-        ev.stopPropagation();
-      });
+    });
 
-      let debounceTimer: ReturnType<typeof setTimeout> | undefined;
-      $('input', this).on('keyup change', function (this: HTMLInputElement) {
-        const value = this.value;
-        if (debounceTimer !== undefined) {
-          clearTimeout(debounceTimer);
-        }
-        debounceTimer = setTimeout(() => {
-          if (dataTable.column(i).search() !== value) {
-            dataTable.column(i).search(value).draw();
+    // Delegated handlers on the table container survive DataTables' per-draw
+    // clone refresh, so they fire on whichever thead instance the user is
+    // actually interacting with (the visible clone in `.dt-scroll-head`).
+    const $container = $(dataTable.table(0).container());
+    const debounceTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+    $container.on('click.columnFilter', 'tr.column-filter th', function (ev) {
+      ev.stopPropagation();
+    });
+
+    $container.on('keyup.columnFilter change.columnFilter', 'input.column-filter', function (this: HTMLInputElement) {
+      const columnIndex = $(this).closest('th').index();
+      const value = this.value;
+      const existing = debounceTimers.get(columnIndex);
+      if (existing !== undefined) {
+        clearTimeout(existing);
+      }
+      debounceTimers.set(
+        columnIndex,
+        setTimeout(() => {
+          if (dataTable.column(columnIndex).search() !== value) {
+            dataTable.column(columnIndex).search(value).draw();
           }
-        }, 250);
-      });
+        }, 250),
+      );
     });
 
     // Resync header clone (scrollX) and body widths now that the thead has
@@ -290,7 +303,15 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
               regex: true,
               smart: false,
             },
-            searching: props.options.searchEnabled,
+            // Column filters drive `.column(i).search()`, which requires
+            // DataTables' search feature to be enabled. When the user has
+            // only turned on column filters (not the global search box),
+            // keep the feature on but suppress the top-end search control
+            // via layout so no stray global input appears.
+            searching: props.options.searchEnabled || props.options.columnFiltersEnabled,
+            ...(!props.options.searchEnabled && props.options.columnFiltersEnabled
+              ? { layout: { topEnd: null } }
+              : {}),
             //select: selectSettings,
             stateSave: false,
             initComplete: function () {

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -69,29 +69,54 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
 
   const enableColumnFilters = (dataTable: any) => {
     const header = dataTable.table(0).header();
-    const newHeaders = $(header)
-      .children('tr')
-      .clone();
+    const $header = $(header);
+
+    // Idempotency guard — don't stack rows on re-invocation
+    if ($header.find('tr.column-filter').length > 0) {
+      return;
+    }
+
+    // Clone the existing header row; strip only sort-interactivity classes so
+    // DataTables' layout classes (dt-*, width hints) survive and keep the
+    // filter cells aligned with the body columns.
+    const newHeaders = $header.children('tr').first().clone();
     newHeaders
+      .addClass('column-filter')
       .find('th')
-      .removeClass()
+      .removeClass('sorting')
+      .removeClass('sorting_asc')
+      .removeClass('sorting_desc')
+      .removeClass('sorting_disabled')
       .addClass('column-filter');
     newHeaders.appendTo(header as Element);
-    $(header)
-      .find(`tr:eq(1) th`)
-      .each(function (i) {
-        let title = textUtil.sanitize($(this).text());
-        $(this).html('<input class="column-filter" type="text" placeholder="Search ' + title + '" />');
 
-        $('input', this).on('keyup change', function (this: any) {
-          if (dataTable.column(i).search() !== this.value) {
-            dataTable
-              .column(i)
-              .search(this.value)
-              .draw();
-          }
-        });
+    // Populate each cloned th with a search input. Clicks on the filter row
+    // must not bubble up to DataTables' header sort handler.
+    $header.find(`tr.column-filter th`).each(function (i) {
+      const $th = $(this);
+      const title = textUtil.sanitize($th.text());
+      $th.html('<input class="column-filter" type="text" placeholder="Search ' + title + '" />');
+      $th.on('click', function (ev) {
+        ev.stopPropagation();
       });
+
+      let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+      $('input', this).on('keyup change', function (this: HTMLInputElement) {
+        const value = this.value;
+        if (debounceTimer !== undefined) {
+          clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => {
+          if (dataTable.column(i).search() !== value) {
+            dataTable.column(i).search(value).draw();
+          }
+        }, 250);
+      });
+    });
+
+    // Resync header clone (scrollX) and body widths now that the thead has
+    // a second row.
+    dataTable.columns.adjust().draw(false);
   };
 
   useEffect(() => {
@@ -268,17 +293,16 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
             searching: props.options.searchEnabled,
             //select: selectSettings,
             stateSave: false,
+            initComplete: function () {
+              if (props.options.columnFiltersEnabled) {
+                enableColumnFilters(this.api());
+              }
+            },
           };
           if (props.options.rowsPerPage) {
             dtOptions.pageLength = props.options.rowsPerPage;
           }
           jQuery(dataTableDOMRef.current).DataTable(dtOptions as Config);
-        }
-      }
-      const currentDom = dataTableDOMRef.current;
-      if (props.options.columnFiltersEnabled) {
-        if (currentDom) {
-          enableColumnFilters(jQuery(currentDom).DataTable());
         }
       }
     }

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -450,6 +450,24 @@ export const getDatatableThemedStyles = (theme: GrafanaTheme2) =>
         table.dataTable tbody td.dt-body-nowrap': {
         whiteSpace: 'nowrap',
       },
+      'table.dataTable thead tr.column-filter th': {
+        padding: '4px 8px',
+        borderTop: `1px solid ${theme.colors.border.weak}`,
+      },
+      'table.dataTable thead tr.column-filter th input.column-filter': {
+        width: '100%',
+        boxSizing: 'border-box',
+        padding: '2px 6px',
+        fontSize: 'inherit',
+        background: theme.colors.background.primary,
+        color: theme.colors.text.primary,
+        border: `1px solid ${theme.colors.border.medium}`,
+        borderRadius: theme.shape.radius.default,
+      },
+      'table.dataTable thead tr.column-filter th input.column-filter:focus': {
+        outline: 'none',
+        borderColor: theme.colors.primary.border,
+      },
       /*
        * Table styles
        */

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -212,7 +212,10 @@ export const BuildColumnDefs = (
             return returnValue.valueRaw;
           }
           if (type === 'filter') {
-            return returnValue.valueRaw;
+            // WYSIWYG: filter against the displayed value so users match
+            // what they see in the cell (e.g. "5.00" with decimals/units)
+            // rather than the underlying numeric value.
+            return returnValue.valueFormatted;
           }
           // all others get the formatted value
           return returnValue.valueFormatted;

--- a/tests/phase3-panel/column-filter-alignment.spec.ts
+++ b/tests/phase3-panel/column-filter-alignment.spec.ts
@@ -1,10 +1,15 @@
 import { expect, test } from '@grafana/plugin-e2e';
 
 // Regression test for issue #278. When "Filter by column" is enabled,
-// the injected filter row must stay aligned with body columns: every
-// filter-row <th> must match the corresponding body <td> width within
-// 1px. Before the fix the filter-row cells stretched wider than the
-// body's cached column widths and content visibly spilled.
+// DataTables runs in scrollX mode, which splits the table into a visible
+// header clone (.dataTables_scrollHead) and the body (.dataTables_scrollBody).
+// Each filter-row <th> in the header clone must match the body <td> width
+// at the same column index — otherwise content visibly spills.
+
+const HEAD_TABLE = '.dataTables_scrollHead table';
+const BODY_TABLE = '.dataTables_scrollBody table';
+const BODY_ROWS = `${BODY_TABLE} tbody tr`;
+
 test.describe('column filter alignment (issue #278)', () => {
   test('filter-row columns align with body columns', async ({
     readProvisionedDashboard,
@@ -21,41 +26,57 @@ test.describe('column filter alignment (issue #278)', () => {
       await gotoDashboardPage({ uid: dashboard.uid });
     });
 
-    await test.step('wait for datatable to render', async () => {
-      await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
+    await test.step('wait for datatable body to render', async () => {
+      await expect(page.locator(BODY_ROWS).first()).toBeVisible({ timeout: 15000 });
     });
 
-    const filterRow = page.locator('table thead tr.column-filter');
-
-    await test.step('filter row is present', async () => {
-      await expect(filterRow).toBeVisible({ timeout: 10000 });
+    await test.step('filter row is present in the visible header', async () => {
+      await expect(
+        page.locator(`${HEAD_TABLE} thead tr.column-filter`),
+      ).toBeVisible({ timeout: 10000 });
     });
 
     await test.step('every filter-row cell matches its body cell width', async () => {
       const mismatches = await page.evaluate(() => {
-        const table = document.querySelector<HTMLTableElement>('table.dataTable');
-        if (!table) {
-          return ['no dataTable found'];
+        const headerTable = document.querySelector<HTMLTableElement>(
+          '.dataTables_scrollHead table',
+        );
+        const bodyTable = document.querySelector<HTMLTableElement>(
+          '.dataTables_scrollBody table',
+        );
+        if (!headerTable || !bodyTable) {
+          return [`scrollX wrappers missing: head=${!!headerTable}, body=${!!bodyTable}`];
         }
         const filterThs = Array.from(
-          table.querySelectorAll<HTMLTableCellElement>('thead tr.column-filter th'),
+          headerTable.querySelectorAll<HTMLTableCellElement>(
+            'thead tr.column-filter th',
+          ),
         );
-        const firstBodyRow = table.querySelector<HTMLTableRowElement>('tbody tr');
+        if (filterThs.length === 0) {
+          return ['no filter-row <th> cells found'];
+        }
+        const firstBodyRow = bodyTable.querySelector<HTMLTableRowElement>(
+          'tbody tr:not(:has(td.dataTables_empty))',
+        );
         if (!firstBodyRow) {
-          return ['no body row'];
+          return ['no non-empty body row'];
         }
         const bodyTds = Array.from(
           firstBodyRow.querySelectorAll<HTMLTableCellElement>('td'),
         );
         if (filterThs.length !== bodyTds.length) {
-          return [`column count mismatch: ${filterThs.length} filter vs ${bodyTds.length} body`];
+          return [
+            `column count mismatch: ${filterThs.length} filter vs ${bodyTds.length} body`,
+          ];
         }
         const out: string[] = [];
         filterThs.forEach((th, i) => {
           const thW = th.getBoundingClientRect().width;
           const tdW = bodyTds[i].getBoundingClientRect().width;
           if (Math.abs(thW - tdW) > 1) {
-            out.push(`col ${i}: filter th=${thW.toFixed(2)}px, body td=${tdW.toFixed(2)}px`);
+            out.push(
+              `col ${i}: filter th=${thW.toFixed(2)}px, body td=${tdW.toFixed(2)}px`,
+            );
           }
         });
         return out;
@@ -79,36 +100,38 @@ test.describe('column filter alignment (issue #278)', () => {
       await gotoDashboardPage({ uid: dashboard.uid });
     });
 
-    await test.step('wait for datatable to render', async () => {
-      await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
+    await test.step('wait for datatable body to render', async () => {
+      await expect(page.locator(BODY_ROWS).first()).toBeVisible({ timeout: 15000 });
     });
 
     const firstFilterInput = page
-      .locator('table thead tr.column-filter th input.column-filter')
+      .locator(`${HEAD_TABLE} thead tr.column-filter th input.column-filter`)
       .first();
     await expect(firstFilterInput).toBeVisible({ timeout: 10000 });
 
-    const baseline = await page.locator('table tbody tr').count();
+    const baseline = await page.locator(BODY_ROWS).count();
 
-    await test.step('fixture sanity: baseline has more than one row', () => {
+    await test.step('fixture sanity: baseline has more than one body row', () => {
       expect(baseline).toBeGreaterThanOrEqual(2);
     });
 
     await test.step('fill a non-matching value and see empty-state appear', async () => {
       await firstFilterInput.fill('zzzzzzzzz-unlikely-match');
       // debounce is 250ms; poll up to 3s
-      await expect(page.locator('table tbody td.dataTables_empty')).toBeVisible({
-        timeout: 3000,
-      });
-      await expect(page.locator('table tbody tr')).toHaveCount(1);
+      await expect(
+        page.locator(`${BODY_TABLE} tbody td.dataTables_empty`),
+      ).toBeVisible({ timeout: 3000 });
+      await expect(page.locator(BODY_ROWS)).toHaveCount(1);
     });
 
     await test.step('clear and see rows restored', async () => {
       await firstFilterInput.fill('');
       await expect
-        .poll(() => page.locator('table tbody tr').count(), { timeout: 3000 })
+        .poll(() => page.locator(BODY_ROWS).count(), { timeout: 3000 })
         .toBe(baseline);
-      await expect(page.locator('table tbody td.dataTables_empty')).toHaveCount(0);
+      await expect(
+        page.locator(`${BODY_TABLE} tbody td.dataTables_empty`),
+      ).toHaveCount(0);
     });
   });
 });

--- a/tests/phase3-panel/column-filter-alignment.spec.ts
+++ b/tests/phase3-panel/column-filter-alignment.spec.ts
@@ -32,7 +32,7 @@ test.describe('column filter alignment (issue #278)', () => {
 
     await test.step('filter row is present in the visible header', async () => {
       await expect(
-        page.locator(`${HEAD_TABLE} thead tr.column-filter`),
+        page.locator(`${HEAD_TABLE} thead tr:has(th.column-filter)`),
       ).toBeVisible({ timeout: 10000 });
     });
 
@@ -49,7 +49,7 @@ test.describe('column filter alignment (issue #278)', () => {
         }
         const filterThs = Array.from(
           headerTable.querySelectorAll<HTMLTableCellElement>(
-            'thead tr.column-filter th',
+            'thead tr:has(th.column-filter) th',
           ),
         );
         if (filterThs.length === 0) {
@@ -105,7 +105,7 @@ test.describe('column filter alignment (issue #278)', () => {
     });
 
     const firstFilterInput = page
-      .locator(`${HEAD_TABLE} thead tr.column-filter th input.column-filter`)
+      .locator(`${HEAD_TABLE} thead tr:has(th.column-filter) th input.column-filter`)
       .first();
     await expect(firstFilterInput).toBeVisible({ timeout: 10000 });
 

--- a/tests/phase3-panel/column-filter-alignment.spec.ts
+++ b/tests/phase3-panel/column-filter-alignment.spec.ts
@@ -2,12 +2,12 @@ import { expect, test } from '@grafana/plugin-e2e';
 
 // Regression test for issue #278. When "Filter by column" is enabled,
 // DataTables runs in scrollX mode, which splits the table into a visible
-// header clone (.dataTables_scrollHead) and the body (.dataTables_scrollBody).
+// header clone (.dt-scroll-head) and the body (.dt-scroll-body).
 // Each filter-row <th> in the header clone must match the body <td> width
 // at the same column index — otherwise content visibly spills.
 
-const HEAD_TABLE = '.dataTables_scrollHead table';
-const BODY_TABLE = '.dataTables_scrollBody table';
+const HEAD_TABLE = '.dt-scroll-head table';
+const BODY_TABLE = '.dt-scroll-body table';
 const BODY_ROWS = `${BODY_TABLE} tbody tr`;
 
 test.describe('column filter alignment (issue #278)', () => {
@@ -39,10 +39,10 @@ test.describe('column filter alignment (issue #278)', () => {
     await test.step('every filter-row cell matches its body cell width', async () => {
       const mismatches = await page.evaluate(() => {
         const headerTable = document.querySelector<HTMLTableElement>(
-          '.dataTables_scrollHead table',
+          '.dt-scroll-head table',
         );
         const bodyTable = document.querySelector<HTMLTableElement>(
-          '.dataTables_scrollBody table',
+          '.dt-scroll-body table',
         );
         if (!headerTable || !bodyTable) {
           return [`scrollX wrappers missing: head=${!!headerTable}, body=${!!bodyTable}`];
@@ -56,7 +56,7 @@ test.describe('column filter alignment (issue #278)', () => {
           return ['no filter-row <th> cells found'];
         }
         const firstBodyRow = bodyTable.querySelector<HTMLTableRowElement>(
-          'tbody tr:not(:has(td.dataTables_empty))',
+          'tbody tr:not(:has(td.dt-empty))',
         );
         if (!firstBodyRow) {
           return ['no non-empty body row'];
@@ -85,7 +85,7 @@ test.describe('column filter alignment (issue #278)', () => {
     });
   });
 
-  test('typing filters rows to the empty state; clearing restores them', async ({
+  test('filter inputs are interactive and placeholder-labelled per column', async ({
     readProvisionedDashboard,
     gotoDashboardPage,
     page,
@@ -104,34 +104,43 @@ test.describe('column filter alignment (issue #278)', () => {
       await expect(page.locator(BODY_ROWS).first()).toBeVisible({ timeout: 15000 });
     });
 
-    const firstFilterInput = page
-      .locator(`${HEAD_TABLE} thead tr:has(th.column-filter) th input.column-filter`)
-      .first();
-    await expect(firstFilterInput).toBeVisible({ timeout: 10000 });
+    const filterInputs = page.locator(
+      `${HEAD_TABLE} thead tr:has(th.column-filter) th input.column-filter`,
+    );
 
-    const baseline = await page.locator(BODY_ROWS).count();
-
-    await test.step('fixture sanity: baseline has more than one body row', () => {
-      expect(baseline).toBeGreaterThanOrEqual(2);
+    await test.step('one filter input per column, each carrying a Search placeholder', async () => {
+      const count = await filterInputs.count();
+      expect(count).toBeGreaterThanOrEqual(2);
+      for (let i = 0; i < count; i++) {
+        const placeholder = await filterInputs.nth(i).getAttribute('placeholder');
+        expect(placeholder).toMatch(/^Search /);
+      }
     });
 
-    await test.step('fill a non-matching value and see empty-state appear', async () => {
-      await firstFilterInput.fill('zzzzzzzzz-unlikely-match');
-      // debounce is 250ms; poll up to 3s
-      await expect(
-        page.locator(`${BODY_TABLE} tbody td.dataTables_empty`),
-      ).toBeVisible({ timeout: 3000 });
-      await expect(page.locator(BODY_ROWS)).toHaveCount(1);
+    await test.step('clicking a filter input focuses it and does not trigger sort', async () => {
+      const firstInput = filterInputs.first();
+      // Snapshot the header-sort classes before interacting with the filter.
+      const sortBefore = await page
+        .locator(`${HEAD_TABLE} thead tr:not(:has(th.column-filter)) th`)
+        .first()
+        .getAttribute('class');
+
+      await firstInput.click();
+      await expect(firstInput).toBeFocused();
+
+      const sortAfter = await page
+        .locator(`${HEAD_TABLE} thead tr:not(:has(th.column-filter)) th`)
+        .first()
+        .getAttribute('class');
+      expect(sortAfter).toBe(sortBefore);
     });
 
-    await test.step('clear and see rows restored', async () => {
-      await firstFilterInput.fill('');
-      await expect
-        .poll(() => page.locator(BODY_ROWS).count(), { timeout: 3000 })
-        .toBe(baseline);
-      await expect(
-        page.locator(`${BODY_TABLE} tbody td.dataTables_empty`),
-      ).toHaveCount(0);
+    await test.step('typing into the input updates its value', async () => {
+      const firstInput = filterInputs.first();
+      await firstInput.fill('filter-probe');
+      await expect(firstInput).toHaveValue('filter-probe');
+      await firstInput.fill('');
+      await expect(firstInput).toHaveValue('');
     });
   });
 });

--- a/tests/phase3-panel/column-filter-alignment.spec.ts
+++ b/tests/phase3-panel/column-filter-alignment.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+// Regression test for issue #278. When "Filter by column" is enabled,
+// the injected filter row must line up with the body cells: each filter
+// input must fit inside its column's header cell. Before the fix the
+// inputs were unsized and pushed the column wider than the body's
+// cached column width, causing visible spill.
+test.describe('column filter alignment (issue #278)', () => {
+  test('filter row renders inside thead and inputs fit their cells', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    page,
+  }) => {
+    const dashboard = await test.step('load provisioned dashboard', async () => {
+      return readProvisionedDashboard({
+        fileName: 'dashboards/Datatable-ColumnFilter.json',
+      });
+    });
+
+    await test.step('open dashboard', async () => {
+      await gotoDashboardPage({ uid: dashboard.uid });
+    });
+
+    await test.step('wait for datatable to render', async () => {
+      await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
+    });
+
+    const filterRow = page.locator('table thead tr.column-filter');
+
+    await test.step('filter row is present', async () => {
+      await expect(filterRow).toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('every filter input fits inside its header cell', async () => {
+      const overflows = await filterRow.evaluate((row) => {
+        const ths = Array.from(row.querySelectorAll<HTMLTableCellElement>('th'));
+        return ths
+          .map((th) => {
+            const input = th.querySelector<HTMLInputElement>('input.column-filter');
+            if (!input) {
+              return null;
+            }
+            const inputWidth = input.getBoundingClientRect().width;
+            const cellWidth = th.getBoundingClientRect().width;
+            // allow 1px rounding tolerance
+            return inputWidth > cellWidth + 1
+              ? { inputWidth, cellWidth }
+              : null;
+          })
+          .filter(Boolean);
+      });
+      expect(overflows).toEqual([]);
+    });
+  });
+
+  test('typing into a filter narrows the visible rows; clearing restores them', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    page,
+  }) => {
+    const dashboard = await readProvisionedDashboard({
+      fileName: 'dashboards/Datatable-ColumnFilter.json',
+    });
+    await gotoDashboardPage({ uid: dashboard.uid });
+    await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
+
+    const firstFilterInput = page.locator('table thead tr.column-filter th input.column-filter').first();
+    await expect(firstFilterInput).toBeVisible({ timeout: 10000 });
+
+    const baseline = await page.locator('table tbody tr').count();
+    expect(baseline).toBeGreaterThan(0);
+
+    await firstFilterInput.fill('zzzzzzzzz-unlikely-match');
+    // debounce is 250ms; poll up to 3s
+    await expect
+      .poll(() => page.locator('table tbody tr').count(), { timeout: 3000 })
+      .toBeLessThan(baseline);
+
+    await firstFilterInput.fill('');
+    await expect
+      .poll(() => page.locator('table tbody tr').count(), { timeout: 3000 })
+      .toBe(baseline);
+  });
+});

--- a/tests/phase3-panel/column-filter-alignment.spec.ts
+++ b/tests/phase3-panel/column-filter-alignment.spec.ts
@@ -1,12 +1,12 @@
 import { expect, test } from '@grafana/plugin-e2e';
 
 // Regression test for issue #278. When "Filter by column" is enabled,
-// the injected filter row must line up with the body cells: each filter
-// input must fit inside its column's header cell. Before the fix the
-// inputs were unsized and pushed the column wider than the body's
-// cached column width, causing visible spill.
+// the injected filter row must stay aligned with body columns: every
+// filter-row <th> must match the corresponding body <td> width within
+// 1px. Before the fix the filter-row cells stretched wider than the
+// body's cached column widths and content visibly spilled.
 test.describe('column filter alignment (issue #278)', () => {
-  test('filter row renders inside thead and inputs fit their cells', async ({
+  test('filter-row columns align with body columns', async ({
     readProvisionedDashboard,
     gotoDashboardPage,
     page,
@@ -31,54 +31,84 @@ test.describe('column filter alignment (issue #278)', () => {
       await expect(filterRow).toBeVisible({ timeout: 10000 });
     });
 
-    await test.step('every filter input fits inside its header cell', async () => {
-      const overflows = await filterRow.evaluate((row) => {
-        const ths = Array.from(row.querySelectorAll<HTMLTableCellElement>('th'));
-        return ths
-          .map((th) => {
-            const input = th.querySelector<HTMLInputElement>('input.column-filter');
-            if (!input) {
-              return null;
-            }
-            const inputWidth = input.getBoundingClientRect().width;
-            const cellWidth = th.getBoundingClientRect().width;
-            // allow 1px rounding tolerance
-            return inputWidth > cellWidth + 1
-              ? { inputWidth, cellWidth }
-              : null;
-          })
-          .filter(Boolean);
+    await test.step('every filter-row cell matches its body cell width', async () => {
+      const mismatches = await page.evaluate(() => {
+        const table = document.querySelector<HTMLTableElement>('table.dataTable');
+        if (!table) {
+          return ['no dataTable found'];
+        }
+        const filterThs = Array.from(
+          table.querySelectorAll<HTMLTableCellElement>('thead tr.column-filter th'),
+        );
+        const firstBodyRow = table.querySelector<HTMLTableRowElement>('tbody tr');
+        if (!firstBodyRow) {
+          return ['no body row'];
+        }
+        const bodyTds = Array.from(
+          firstBodyRow.querySelectorAll<HTMLTableCellElement>('td'),
+        );
+        if (filterThs.length !== bodyTds.length) {
+          return [`column count mismatch: ${filterThs.length} filter vs ${bodyTds.length} body`];
+        }
+        const out: string[] = [];
+        filterThs.forEach((th, i) => {
+          const thW = th.getBoundingClientRect().width;
+          const tdW = bodyTds[i].getBoundingClientRect().width;
+          if (Math.abs(thW - tdW) > 1) {
+            out.push(`col ${i}: filter th=${thW.toFixed(2)}px, body td=${tdW.toFixed(2)}px`);
+          }
+        });
+        return out;
       });
-      expect(overflows).toEqual([]);
+      expect(mismatches).toEqual([]);
     });
   });
 
-  test('typing into a filter narrows the visible rows; clearing restores them', async ({
+  test('typing filters rows to the empty state; clearing restores them', async ({
     readProvisionedDashboard,
     gotoDashboardPage,
     page,
   }) => {
-    const dashboard = await readProvisionedDashboard({
-      fileName: 'dashboards/Datatable-ColumnFilter.json',
+    const dashboard = await test.step('load provisioned dashboard', async () => {
+      return readProvisionedDashboard({
+        fileName: 'dashboards/Datatable-ColumnFilter.json',
+      });
     });
-    await gotoDashboardPage({ uid: dashboard.uid });
-    await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
 
-    const firstFilterInput = page.locator('table thead tr.column-filter th input.column-filter').first();
+    await test.step('open dashboard', async () => {
+      await gotoDashboardPage({ uid: dashboard.uid });
+    });
+
+    await test.step('wait for datatable to render', async () => {
+      await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 15000 });
+    });
+
+    const firstFilterInput = page
+      .locator('table thead tr.column-filter th input.column-filter')
+      .first();
     await expect(firstFilterInput).toBeVisible({ timeout: 10000 });
 
     const baseline = await page.locator('table tbody tr').count();
-    expect(baseline).toBeGreaterThan(0);
 
-    await firstFilterInput.fill('zzzzzzzzz-unlikely-match');
-    // debounce is 250ms; poll up to 3s
-    await expect
-      .poll(() => page.locator('table tbody tr').count(), { timeout: 3000 })
-      .toBeLessThan(baseline);
+    await test.step('fixture sanity: baseline has more than one row', () => {
+      expect(baseline).toBeGreaterThanOrEqual(2);
+    });
 
-    await firstFilterInput.fill('');
-    await expect
-      .poll(() => page.locator('table tbody tr').count(), { timeout: 3000 })
-      .toBe(baseline);
+    await test.step('fill a non-matching value and see empty-state appear', async () => {
+      await firstFilterInput.fill('zzzzzzzzz-unlikely-match');
+      // debounce is 250ms; poll up to 3s
+      await expect(page.locator('table tbody td.dataTables_empty')).toBeVisible({
+        timeout: 3000,
+      });
+      await expect(page.locator('table tbody tr')).toHaveCount(1);
+    });
+
+    await test.step('clear and see rows restored', async () => {
+      await firstFilterInput.fill('');
+      await expect
+        .poll(() => page.locator('table tbody tr').count(), { timeout: 3000 })
+        .toBe(baseline);
+      await expect(page.locator('table tbody td.dataTables_empty')).toHaveCount(0);
+    });
   });
 });

--- a/tests/phase3-panel/column-filter-many-columns.spec.ts
+++ b/tests/phase3-panel/column-filter-many-columns.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+// Multi-column regression coverage for issue #278. The original issue
+// screenshot showed ten-plus series with the filter row visibly misaligned;
+// this spec loads a provisioned dashboard with eight random-walk series
+// (A-series through H-series, plus the time column = 9 columns) and asserts
+// alignment + live-typing filter behavior across every column.
+
+const HEAD_TABLE = '.dt-scroll-head table';
+const BODY_TABLE = '.dt-scroll-body table';
+const BODY_ROWS = `${BODY_TABLE} tbody tr`;
+
+test.describe('column filter with many columns (issue #278, multi-column)', () => {
+  test('every filter-row cell stays aligned with its body cell across 9 columns', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    page,
+  }) => {
+    const dashboard = await test.step('load provisioned dashboard', async () => {
+      return readProvisionedDashboard({
+        fileName: 'dashboards/Datatable-ColumnFilter-ManyColumns.json',
+      });
+    });
+
+    await test.step('open dashboard', async () => {
+      await gotoDashboardPage({ uid: dashboard.uid });
+    });
+
+    await test.step('wait for datatable body to render', async () => {
+      await expect(page.locator(BODY_ROWS).first()).toBeVisible({ timeout: 15000 });
+    });
+
+    await test.step('filter row is present in the visible header', async () => {
+      await expect(
+        page.locator(`${HEAD_TABLE} thead tr:has(th.column-filter)`),
+      ).toBeVisible({ timeout: 10000 });
+    });
+
+    await test.step('table has 9 columns (time + A-H series)', async () => {
+      const headerCount = await page
+        .locator(`${HEAD_TABLE} thead tr:not(:has(th.column-filter)) th`)
+        .count();
+      expect(headerCount).toBe(9);
+      const filterInputs = await page
+        .locator(`${HEAD_TABLE} input.column-filter`)
+        .count();
+      expect(filterInputs).toBe(9);
+    });
+
+    await test.step('every filter-row cell matches its body cell width', async () => {
+      const mismatches = await page.evaluate(() => {
+        const headerTable = document.querySelector<HTMLTableElement>(
+          '.dt-scroll-head table',
+        );
+        const bodyTable = document.querySelector<HTMLTableElement>(
+          '.dt-scroll-body table',
+        );
+        if (!headerTable || !bodyTable) {
+          return [`scrollX wrappers missing: head=${!!headerTable}, body=${!!bodyTable}`];
+        }
+        const filterThs = Array.from(
+          headerTable.querySelectorAll<HTMLTableCellElement>(
+            'thead tr:has(th.column-filter) th',
+          ),
+        );
+        const firstBodyRow = bodyTable.querySelector<HTMLTableRowElement>(
+          'tbody tr:not(:has(td.dt-empty))',
+        );
+        if (!firstBodyRow) {
+          return ['no non-empty body row'];
+        }
+        const bodyTds = Array.from(
+          firstBodyRow.querySelectorAll<HTMLTableCellElement>('td'),
+        );
+        if (filterThs.length !== bodyTds.length) {
+          return [
+            `column count mismatch: ${filterThs.length} filter vs ${bodyTds.length} body`,
+          ];
+        }
+        const out: string[] = [];
+        filterThs.forEach((th, i) => {
+          const thW = th.getBoundingClientRect().width;
+          const tdW = bodyTds[i].getBoundingClientRect().width;
+          if (Math.abs(thW - tdW) > 1) {
+            out.push(
+              `col ${i}: filter th=${thW.toFixed(2)}px, body td=${tdW.toFixed(2)}px`,
+            );
+          }
+        });
+        return out;
+      });
+      expect(mismatches).toEqual([]);
+    });
+  });
+
+  test('typing a WYSIWYG value into a filter narrows rows to matches', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    page,
+  }) => {
+    const dashboard = await readProvisionedDashboard({
+      fileName: 'dashboards/Datatable-ColumnFilter-ManyColumns.json',
+    });
+    await gotoDashboardPage({ uid: dashboard.uid });
+    await expect(page.locator(BODY_ROWS).first()).toBeVisible({ timeout: 15000 });
+
+    // Use DataTables' own API to read row counts — page.locator counts every
+    // rendered row including the off-screen ones DataTables keeps in the DOM
+    // for virtual scrolling.
+    const rowsInfo = async () =>
+      page.evaluate(() => {
+        const $ = (window as unknown as { jQuery: JQueryStatic }).jQuery;
+        const api = $('.dt-scroll-body table.dataTable').DataTable();
+        return {
+          totalRecords: api.page.info().recordsTotal,
+          displayRecords: api.page.info().recordsDisplay,
+        };
+      });
+
+    const baseline = await rowsInfo();
+
+    await test.step('fixture sanity: baseline >= 2 records and all shown', () => {
+      expect(baseline.totalRecords).toBeGreaterThanOrEqual(2);
+      expect(baseline.displayRecords).toBe(baseline.totalRecords);
+    });
+
+    // A-series is configured with decimals=2 in the fixture, so values render
+    // as e.g. "5.00". Filtering against the displayed value proves WYSIWYG
+    // filter-orthogonal data is wired up correctly.
+    const aSeriesInput = page
+      .locator(`${HEAD_TABLE} input.column-filter`)
+      .nth(1);
+
+    await test.step('type "5.00" into A-series filter — matches the formatted display', async () => {
+      await aSeriesInput.click();
+      await aSeriesInput.pressSequentially('5.00', { delay: 30 });
+      await expect
+        .poll(async () => (await rowsInfo()).displayRecords, { timeout: 3000 })
+        .toBeLessThan(baseline.totalRecords);
+      const searchApplied = await page.evaluate(() => {
+        const $ = (window as unknown as { jQuery: JQueryStatic }).jQuery;
+        return $('.dt-scroll-body table.dataTable').DataTable().column(1).search();
+      });
+      expect(searchApplied).toBe('5.00');
+    });
+
+    await test.step('clear the filter — all rows return', async () => {
+      // Triple-click selects the entire input value, then type backspace to clear
+      // and fire keyup so the delegated handler reruns the column search.
+      await aSeriesInput.click({ clickCount: 3 });
+      await aSeriesInput.press('Backspace');
+      await expect
+        .poll(async () => (await rowsInfo()).displayRecords, { timeout: 3000 })
+        .toBe(baseline.totalRecords);
+    });
+
+    // Second column filter works independently of the first — delegated
+    // handlers on the container must fire per input, per column.
+    const bSeriesInput = page
+      .locator(`${HEAD_TABLE} input.column-filter`)
+      .nth(2);
+
+    await test.step('type into B-series filter and verify independent narrowing', async () => {
+      await bSeriesInput.click();
+      await bSeriesInput.pressSequentially('99', { delay: 30 });
+      await expect
+        .poll(async () => (await rowsInfo()).displayRecords, { timeout: 3000 })
+        .toBeLessThan(baseline.totalRecords);
+      const searchApplied = await page.evaluate(() => {
+        const $ = (window as unknown as { jQuery: JQueryStatic }).jQuery;
+        const api = $('.dt-scroll-body table.dataTable').DataTable();
+        return { col1: api.column(1).search(), col2: api.column(2).search() };
+      });
+      expect(searchApplied.col2).toBe('99');
+      expect(searchApplied.col1).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes issue #278 (column-filter row misalignment) and several related problems that surfaced while exercising the feature live in the browser. The feature now works end-to-end: the filter row aligns with body columns, typing actually filters, and the first paint no longer flashes un-formatted data.

## What landed

**Alignment (the originally reported #278 symptom)**
- `enableColumnFilters` now runs inside DataTables' `initComplete` so the scrollX header clone and body column widths are both computed before the filter row is injected.
- Targeted class stripping: only `sorting` / `sorting_asc` / `sorting_desc` / `sorting_disabled` are removed from the cloned cells, so `dt-*` alignment classes and width hints survive.
- `columns.adjust().draw(false)` runs after injection to resync the scrollX header clone with the modified source thead.
- Idempotency guard prevents stacked filter rows on re-init.
- Themed CSS sizes every input to `width: 100%` + `box-sizing: border-box` so the input can never push a cell wider than its cached column width (the literal spill symptom in the issue screenshot).

**Filter wiring**
- Handlers moved to jQuery event delegation on `dataTable.table(0).container()`. DataTables re-clones the source thead into `.dt-scroll-head` on every draw; the prior direct bindings lived on inputs users never touched, so typing did nothing. Delegated handlers survive the clone refresh.
- Click propagation is stopped on filter-row `<th>` cells so a filter click can't trigger a header sort.
- Debounce timers live in a per-column `Map`, so each column keeps an independent 250 ms window across draws.
- DataTables' `searching` feature is now enabled whenever `columnFiltersEnabled` is on. Previously, users with `searchEnabled: false` had `searching: false`, which silently disabled `api.column(i).search()` — the visible inputs accepted text but nothing filtered. A `layout: { topEnd: null }` override on that branch suppresses the stray global search control so no unwanted search box appears.
- Per-column filtering is now **WYSIWYG**: DataTables' `filter` orthogonal data returns `valueFormatted` (e.g. `"5.00"`) instead of `valueRaw` (`5`). Users match what they see in the cell. Sort mode still uses `valueRaw` so numeric sort stays numeric.

**First-paint flash**
- A `dataTableReady` state stays false until `initComplete` fires; a themed loading overlay covers the wrapper and the `<table>` carries `visibility: hidden` until then. No more brief flash of un-formatted rows before threshold colors, formatters, and the filter row settle in. Re-inits also re-hide through the overlay so no transient draws leak through.

**Code-review hardening**
- Delegated `.columnFilter` jQuery handlers are now explicitly detached from the `.dt-container` wrapper before DataTables' `destroy()`, so any destroy path that retains the container element cannot accumulate stale listeners across re-inits.
- Filter `<input>` elements are now constructed via `document.createElement` rather than `$th.html(templated-string)`. A column alias or title containing a `"` character can no longer break out of the placeholder attribute (`textUtil.sanitize` strips HTML tags but does not escape attribute-context quotes).
- `setDataTableReady(true)` inside `initComplete` is gated on a `mountedRef` so the async DataTables callback cannot setState on an unmounted component (dashboard swap, options change mid-init).

**Tests**
- `tests/phase3-panel/column-filter-alignment.spec.ts` + `provisioning/dashboards/dashboards/Datatable-ColumnFilter.json` — asserts filter-row `<th>` width matches body `<td>` width within 1 px across the scrollX-split tables, and checks filter-row interactivity (placeholder per column, click focuses without triggering sort, input accepts text).
- `tests/phase3-panel/column-filter-many-columns.spec.ts` + `provisioning/dashboards/dashboards/Datatable-ColumnFilter-ManyColumns.json` — nine columns (time + A-H random-walk series, matching the shape of the original issue screenshot). Asserts alignment across every column plus real end-to-end filter behavior via native keyup events: typing `5.00` into the A-series filter narrows the row set, clearing restores baseline, and typing into B-series narrows independently with `column(1).search()` still empty (delegated handlers stay per-column).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 67 unit tests pass
- [x] `pnpm e2e` — 11/11 E2E tests pass (2 new alignment + 2 new multi-column)
- [x] Manual: filter row aligns in dark + light theme, typing filters, clear restores, header sort still works, clicking input does not sort, first paint shows loading overlay until DataTables is fully initialized