### PR TITLE
fix(clickthrough): preserve host:port + accept relative URLs (closes #276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,7 +266,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   are emitted verbatim. `url.hash` (fragments like `#panel-2`) is now
   preserved, and the trailing `?` no longer appears when the query is
   empty. Supported URL forms are documented in the README. Regression
-  pinned with six parameterized cases in `src/data/cellRenderer.test.ts`.
+  pinned with six parameterized cases in `src/data/cellRenderer.test.ts`
+  plus an end-to-end spec
+  (`tests/phase3-panel/clickthrough-urls.spec.ts`) that loads a
+  provisioned dashboard and asserts the rendered `<a href>` for
+  host:port and relative clickthroughs across multiple rows.
 
 ### Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   previously feed an arbitrary string into the DOM style API. Browsers
   reject invalid `text-align` values so there's no known exploit; this
   hardens the boundary anyway.
+- **Clickthrough URLs preserve host:port and accept relative paths** (closes
+  #276). The URL rebuild in `ProcessClickthrough` used `url.hostname`, which
+  drops the port (`http://host:8080/x` → `http://host/x`), and called
+  `new URL(clickThrough)` without a fallback base, which threw on relative
+  paths like `/d/uid/slug` and caused the panel to fail to render. The
+  rebuild now branches: HTTP/HTTPS URLs are parsed with `url.host` (port
+  preserved), path-relative inputs (leading `/`, not `//`) are parsed with
+  `window.location.origin` as the base so nothing throws, and non-HTTP
+  schemes or protocol-relative inputs (`mailto:`, `ftp://`, `//host/path`)
+  are emitted verbatim. `url.hash` (fragments like `#panel-2`) is now
+  preserved, and the trailing `?` no longer appears when the query is
+  empty. Supported URL forms are documented in the README. Regression
+  pinned with six parameterized cases in `src/data/cellRenderer.test.ts`.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ Once the url is specified, additional options are displayed that provide additon
 
 Additional you can specify if the URL should be open in a new tab or new window, and specify a custom target.
 
+#### Supported URL Formats
+
+| Form | Example | Behavior |
+| --- | --- | --- |
+| Absolute with port | `http://host.example:8080/path?x=1` | Port preserved |
+| Absolute with fragment | `http://host.example/d/uid#panel-2` | Fragment preserved |
+| Absolute, no query | `http://host.example/path` | No trailing `?` appended |
+| Relative | `/d/uid/slug?var=Host=$__pattern_0` | Resolved against the current dashboard origin |
+| Non-HTTP scheme / protocol-relative | `mailto:...`, `ftp://...`, `//host/path` | Emitted verbatim |
+
+Macros (`$__cell_N`, `$__pattern_N`, `$__from`, `$__to`, `$__keepTime`) are expanded before the
+href is constructed, so they work identically in absolute and relative URLs.
+
 #### Pattern Macros
 
 `Split By RegEx` - the cell content of the matching column is split by this regex which can then be used within the URL.

--- a/provisioning/dashboards/dashboards/Datatable-Clickthrough.json
+++ b/provisioning/dashboards/dashboards/Datatable-Clickthrough.json
@@ -1,0 +1,156 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 10,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource",
+        "uid": "P53465F745837BCFD"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "alignNumbersToRightEnabled": true,
+        "alignStringsToRightEnabled": false,
+        "columnAliases": [],
+        "columnFiltersEnabled": false,
+        "columnSorting": [],
+        "columnStylesConfig": [
+          {
+            "activeStyle": "string",
+            "dateStyle": {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss"
+            },
+            "enabled": true,
+            "hiddenStyle": {},
+            "label": "Host-Port",
+            "metricStyle": {
+              "alias": "",
+              "colorMode": "disabled",
+              "colors": ["#299c46", "#ed8128", "#f53636", "#0a55a1"],
+              "decimals": "2",
+              "ignoreNullValues": true,
+              "thresholds": [],
+              "unitFormat": "short"
+            },
+            "nameOrRegex": "Host",
+            "stringStyle": {
+              "clickThrough": "http://monitor.example:8080/hosts/$__cell",
+              "clickThroughCustomTarget": "",
+              "clickThroughCustomTargetEnabled": false,
+              "clickThroughOpenNewTab": true,
+              "clickThroughSanitize": false,
+              "splitByPattern": ""
+            }
+          },
+          {
+            "activeStyle": "string",
+            "dateStyle": {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss"
+            },
+            "enabled": true,
+            "hiddenStyle": {},
+            "label": "Dashboard-Relative",
+            "metricStyle": {
+              "alias": "",
+              "colorMode": "disabled",
+              "colors": ["#299c46", "#ed8128", "#f53636", "#0a55a1"],
+              "decimals": "2",
+              "ignoreNullValues": true,
+              "thresholds": [],
+              "unitFormat": "short"
+            },
+            "nameOrRegex": "Dashboard",
+            "stringStyle": {
+              "clickThrough": "/d/uid/$__cell",
+              "clickThroughCustomTarget": "",
+              "clickThroughCustomTargetEnabled": false,
+              "clickThroughOpenNewTab": true,
+              "clickThroughSanitize": false,
+              "splitByPattern": ""
+            }
+          }
+        ],
+        "columnWidthHints": [],
+        "columns": [],
+        "compactRowsEnabled": false,
+        "datatablePagingType": "simple_numbers",
+        "emptyDataEnabled": true,
+        "emptyDataText": "",
+        "fontSizePercent": "100%",
+        "hoverEnabled": true,
+        "infoEnabled": true,
+        "lengthChangeEnabled": true,
+        "orderColumnEnabled": false,
+        "rowNumbersEnabled": false,
+        "rowsPerPage": 5,
+        "scroll": true,
+        "searchEnabled": false,
+        "searchHighlightingEnabled": false,
+        "stripedRowsEnabled": true,
+        "transformation": "table",
+        "transformationAggregations": ["last"],
+        "wrapToFitEnabled": true
+      },
+      "pluginVersion": "2.0.2",
+      "targets": [
+        {
+          "csvContent": "Host,Dashboard\nweb-01,overview\nweb-02,hosts\nweb-03,services",
+          "datasource": {
+            "type": "grafana-testdata-datasource",
+            "uid": "P53465F745837BCFD"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Clickthrough URLs",
+      "type": "briangann-datatable-panel"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Datatable Clickthrough",
+  "uid": "datatable-clickthrough",
+  "version": 1
+}

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -135,7 +135,7 @@ describe('Cell Renderer', () => {
 
   describe('ProcessClickthrough — URL reconstruction (issue #276)', () => {
     // Minimal stringStyle fixture that exercises the URL-rebuild code path
-    // without triggering macro replacement or sanitisation.
+    // without triggering macro replacement or sanitization.
     const baseStringStyle = {
       clickThrough: '',
       clickThroughOpenNewTab: true,

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -2,7 +2,7 @@
  * Tests for Rendering a Cell
  */
 import { DateFormats } from 'types';
-import { applyFormat, FormatColumnValue, ReplaceTimeMacros, TimeFormatter } from './cellRenderer';
+import { applyFormat, FormatColumnValue, ProcessClickthrough, ReplaceTimeMacros, TimeFormatter } from './cellRenderer';
 import { Field, FieldConfig, FieldType, GrafanaTheme2, TimeRange, dateTime} from '@grafana/data';
 describe('Cell Renderer', () => {
   const theme2 = {} as unknown as GrafanaTheme2;
@@ -130,6 +130,63 @@ describe('Cell Renderer', () => {
       expect(result.valueFormatted).toEqual('123.46 kwh');
       expect(result.valueRounded).toEqual(123.46);
       expect(result.valueRoundedAndFormatted).toEqual('123.46 kwh');
+    });
+  });
+
+  describe('ProcessClickthrough — URL reconstruction (issue #276)', () => {
+    // Minimal stringStyle fixture that exercises the URL-rebuild code path
+    // without triggering macro replacement or sanitisation.
+    const baseStringStyle = {
+      clickThrough: '',
+      clickThroughOpenNewTab: true,
+      clickThroughCustomTargetEnabled: false,
+      clickThroughCustomTarget: '',
+      clickThroughSanitize: false,
+      splitByPattern: '',
+    };
+
+    const fakeTimeRange = {
+      from: dateTime(0),
+      to: dateTime(0),
+      raw: { from: 'now-1h', to: 'now' },
+    } as unknown as TimeRange;
+
+    const processedItem = { valueFormatted: 'cellText' } as any;
+
+    const run = (clickThrough: string) =>
+      ProcessClickthrough(
+        { stringStyle: { ...baseStringStyle, clickThrough } } as any,
+        /* columns */ [],
+        /* rows */ [],
+        /* rowIndex */ 0,
+        processedItem,
+        fakeTimeRange,
+      );
+
+    it.each([
+      {
+        label: 'absolute URL preserves host:port',
+        input: 'http://a.b.c:8080/path?x=1',
+        expected: 'href="http://a.b.c:8080/path?x=1"',
+      },
+      {
+        label: 'relative URL preserves path + query',
+        input: '/d/uid/slug?var=x',
+        expected: 'href="/d/uid/slug?var=x"',
+      },
+      {
+        label: 'absolute URL with no query omits trailing ?',
+        input: 'http://a.b.c/path',
+        expected: 'href="http://a.b.c/path"',
+      },
+      {
+        label: 'absolute URL preserves fragment',
+        input: 'http://a.b.c/d#panel-2',
+        expected: 'href="http://a.b.c/d#panel-2"',
+      },
+    ])('$label', ({ input, expected }) => {
+      const html = run(input);
+      expect(html).toContain(expected);
     });
   });
 });

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -184,6 +184,16 @@ describe('Cell Renderer', () => {
         input: 'http://a.b.c/d#panel-2',
         expected: 'href="http://a.b.c/d#panel-2"',
       },
+      {
+        label: 'non-HTTP scheme is emitted verbatim',
+        input: 'mailto:ops@example.com',
+        expected: 'href="mailto:ops@example.com"',
+      },
+      {
+        label: 'protocol-relative URL is emitted verbatim',
+        input: '//host.example/path',
+        expected: 'href="//host.example/path"',
+      },
     ])('$label', ({ input, expected }) => {
       const html = run(input);
       expect(html).toContain(expected);

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -4,6 +4,8 @@
 import { DateFormats } from 'types';
 import { applyFormat, FormatColumnValue, ProcessClickthrough, ReplaceTimeMacros, TimeFormatter } from './cellRenderer';
 import { Field, FieldConfig, FieldType, GrafanaTheme2, TimeRange, dateTime} from '@grafana/data';
+import { ColumnStyleItemType } from 'components/options/columnstyles/types';
+import { FormattedColumnValue } from './types';
 describe('Cell Renderer', () => {
   const theme2 = {} as unknown as GrafanaTheme2;
   describe('Test FormatColumnValue', () => {
@@ -151,11 +153,11 @@ describe('Cell Renderer', () => {
       raw: { from: 'now-1h', to: 'now' },
     } as unknown as TimeRange;
 
-    const processedItem = { valueFormatted: 'cellText' } as any;
+    const processedItem = { valueFormatted: 'cellText' } as FormattedColumnValue;
 
     const run = (clickThrough: string) =>
       ProcessClickthrough(
-        { stringStyle: { ...baseStringStyle, clickThrough } } as any,
+        { stringStyle: { ...baseStringStyle, clickThrough } } as unknown as ColumnStyleItemType,
         /* columns */ [],
         /* rows */ [],
         /* rowIndex */ 0,

--- a/src/data/cellRenderer.ts
+++ b/src/data/cellRenderer.ts
@@ -14,6 +14,12 @@ import { FormattedColumnValue } from "./types";
 import moment from 'moment-timezone';
 import { ColumnStyleItemType, ColumnStyles } from "components/options/columnstyles/types";
 
+// Fallback base for `new URL(input, base)` when parsing path-relative
+// clickthrough inputs. Dashboards always run in a browser, so
+// `window.location.origin` is the real value; the literal is a one-shot
+// sentinel for non-browser execution (SSR, jest without jsdom).
+const DEFAULT_URL_BASE = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+
 // Similar to DataLinks, this replaces the value of the panel time ranges for use in url params
 export const ReplaceTimeMacros = (timeRange: TimeRange, content: string) => {
   let newContent = content;
@@ -193,13 +199,13 @@ export const ProcessClickthrough = (
 
     let href: string;
     if (isHttp || isPathRelative) {
-      const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
-      const url = new URL(clickThrough, base);
+      // Absolute HTTP URLs ignore the second arg; only the path-relative
+      // branch actually consults it, so skip the origin read on the hot path.
+      const url = new URL(clickThrough, isHttp ? undefined : DEFAULT_URL_BASE);
       const origin = isHttp ? `${url.protocol}//${url.host}` : '';
       const query = url.searchParams.toString();
       const queryString = query ? `?${query}` : '';
-      const hash = url.hash; // already includes leading '#' when present
-      href = `${origin}${url.pathname}${queryString}${hash}`;
+      href = `${origin}${url.pathname}${queryString}${url.hash}`;
     } else {
       // Verbatim path: no URL-API round-trip, no scheme inference,
       // no protocol-relative auto-promotion to the current origin.

--- a/src/data/cellRenderer.ts
+++ b/src/data/cellRenderer.ts
@@ -180,10 +180,21 @@ export const ProcessClickthrough = (
       clickThrough = textUtil.sanitizeUrl(clickThrough);
     }
     // rebuild with encoding of parameters
-    const url = new URL(clickThrough);
-    const encoded = url.searchParams.toString();
-    const rebuildUrl = `${url.protocol}//${url.hostname}${url.pathname}`;
-    const newCell = '<a href="' + rebuildUrl + `?${encoded}" target="${target}">` + processedItem.valueFormatted + '</a>';
+    // - Branch on the original input so we emit the same kind of href the
+    //   user typed (absolute vs relative).
+    // - Use a fallback base so `new URL()` never throws on relative inputs.
+    // - `url.host` (not `.hostname`) preserves host:port.
+    // - Omit the `?` separator entirely when the query is empty.
+    // - Preserve `url.hash` (fragment).
+    const isAbsolute = /^https?:\/\//i.test(clickThrough);
+    const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+    const url = new URL(clickThrough, base);
+    const origin = isAbsolute ? `${url.protocol}//${url.host}` : '';
+    const query = url.searchParams.toString();
+    const queryString = query ? `?${query}` : '';
+    const hash = url.hash; // already includes leading '#' when present
+    const href = `${origin}${url.pathname}${queryString}${hash}`;
+    const newCell = '<a href="' + href + `" target="${target}">` + processedItem.valueFormatted + '</a>';
 
     // TODO: allowing template variables would be a great addition
     //

--- a/src/data/cellRenderer.ts
+++ b/src/data/cellRenderer.ts
@@ -180,20 +180,31 @@ export const ProcessClickthrough = (
       clickThrough = textUtil.sanitizeUrl(clickThrough);
     }
     // rebuild with encoding of parameters
-    // - Branch on the original input so we emit the same kind of href the
-    //   user typed (absolute vs relative).
-    // - Use a fallback base so `new URL()` never throws on relative inputs.
-    // - `url.host` (not `.hostname`) preserves host:port.
-    // - Omit the `?` separator entirely when the query is empty.
-    // - Preserve `url.hash` (fragment).
-    const isAbsolute = /^https?:\/\//i.test(clickThrough);
-    const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
-    const url = new URL(clickThrough, base);
-    const origin = isAbsolute ? `${url.protocol}//${url.host}` : '';
-    const query = url.searchParams.toString();
-    const queryString = query ? `?${query}` : '';
-    const hash = url.hash; // already includes leading '#' when present
-    const href = `${origin}${url.pathname}${queryString}${hash}`;
+    // - HTTP/HTTPS absolute URLs: parse + rebuild to keep host:port and
+    //   re-encode the query string against macro-injected content.
+    // - Path-relative URLs (leading `/`): parse with window.location.origin
+    //   as base so `new URL()` can read pathname/searchParams/hash, then
+    //   emit just the path portion so the href stays relative.
+    // - Non-HTTP schemes (ftp:, mailto:, etc.) and protocol-relative
+    //   (`//host/path`) inputs: emit verbatim. Macro expansion has already
+    //   run; no re-encoding is safe without knowing the scheme's rules.
+    const isHttp = /^https?:\/\//i.test(clickThrough);
+    const isPathRelative = clickThrough.startsWith('/') && !clickThrough.startsWith('//');
+
+    let href: string;
+    if (isHttp || isPathRelative) {
+      const base = typeof window !== 'undefined' ? window.location.origin : 'http://localhost';
+      const url = new URL(clickThrough, base);
+      const origin = isHttp ? `${url.protocol}//${url.host}` : '';
+      const query = url.searchParams.toString();
+      const queryString = query ? `?${query}` : '';
+      const hash = url.hash; // already includes leading '#' when present
+      href = `${origin}${url.pathname}${queryString}${hash}`;
+    } else {
+      // Verbatim path: no URL-API round-trip, no scheme inference,
+      // no protocol-relative auto-promotion to the current origin.
+      href = clickThrough;
+    }
     const newCell = '<a href="' + href + `" target="${target}">` + processedItem.valueFormatted + '</a>';
 
     // TODO: allowing template variables would be a great addition

--- a/tests/phase3-panel/clickthrough-urls.spec.ts
+++ b/tests/phase3-panel/clickthrough-urls.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@grafana/plugin-e2e';
+
+// Regression test for issue #276. Clickthrough URLs with host:port and
+// path-relative clickthrough URLs both regressed in the React port:
+// - `http://host:8080/...` rendered as `http://host/...` (port stripped)
+// - `/d/uid/...` threw `TypeError: Invalid URL` and blanked the panel
+// This spec loads a provisioned dashboard with two string columns —
+// one carrying a port-preserving clickthrough, the other a path-
+// relative clickthrough — and asserts the rendered `<a href>` exactly
+// matches what the user configured (with `$__cell` macro expanded).
+
+test.describe('clickthrough URL rendering (issue #276)', () => {
+  test('host:port and relative URLs render their anchors correctly', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+    page,
+  }) => {
+    const dashboard = await test.step('load provisioned dashboard', async () => {
+      return readProvisionedDashboard({
+        fileName: 'dashboards/Datatable-Clickthrough.json',
+      });
+    });
+
+    await test.step('open dashboard', async () => {
+      await gotoDashboardPage({ uid: dashboard.uid });
+    });
+
+    const firstRow = page.locator('.dt-scroll-body tbody tr').first();
+
+    await test.step('wait for first row to render with anchors', async () => {
+      await expect(firstRow.locator('td a').first()).toBeVisible({ timeout: 15000 });
+    });
+
+    await test.step('Host column anchor preserves host:port', async () => {
+      const hostLink = firstRow.locator('td a').nth(0);
+      await expect(hostLink).toHaveText('web-01');
+      await expect(hostLink).toHaveAttribute(
+        'href',
+        'http://monitor.example:8080/hosts/web-01',
+      );
+    });
+
+    await test.step('Dashboard column anchor is emitted as a relative path', async () => {
+      const dashboardLink = firstRow.locator('td a').nth(1);
+      await expect(dashboardLink).toHaveText('overview');
+      await expect(dashboardLink).toHaveAttribute('href', '/d/uid/overview');
+    });
+
+    await test.step('subsequent rows expand $__cell per row', async () => {
+      const secondRow = page.locator('.dt-scroll-body tbody tr').nth(1);
+      await expect(secondRow.locator('td a').nth(0)).toHaveAttribute(
+        'href',
+        'http://monitor.example:8080/hosts/web-02',
+      );
+      await expect(secondRow.locator('td a').nth(1)).toHaveAttribute(
+        'href',
+        '/d/uid/hosts',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes issue #276 — two regressions in clickthrough URL rendering introduced in the React port.

- **Port preserved** on absolute URLs. `http://host:8080/...` no longer becomes `http://host/...` (was using `url.hostname`, now uses `url.host`).
- **Relative URLs render.** `/d/uid/slug?...` no longer throws `TypeError: Invalid URL` and blows up the panel. Parsed with `window.location.origin` as a fallback base; emitted as a path-relative href.
- **Fragments preserved.** `http://host/d#panel-2` keeps the `#panel-2`.
- **Empty-query cleanup.** `http://host/path` no longer renders with a dangling `?`.
- **Non-HTTP and protocol-relative URLs emitted verbatim.** `mailto:`, `ftp://`, `//host/path` flow through the render untouched.

## What changed

- `src/data/cellRenderer.ts` — rewrote the URL-rebuild block inside `ProcessClickthrough` with `isHttp` / `isPathRelative` classifier + verbatim fallthrough for anything else. Hoisted `DEFAULT_URL_BASE` to module scope so `window.location.origin` is read once at module load, not per cell render.
- `src/data/cellRenderer.test.ts` — 6 parameterized `it.each` cases covering the behavior matrix (port, relative, no query, fragment, `mailto:`, protocol-relative).
- `tests/phase3-panel/clickthrough-urls.spec.ts` + `provisioning/dashboards/dashboards/Datatable-Clickthrough.json` — end-to-end Playwright spec that loads a provisioned dashboard with two string columns (one port-preserving, one relative) and asserts the exact rendered `<a href>` across multiple rows, confirming `$__cell` macro expansion is correct per row.
- `README.md` — new `#### Supported URL Formats` table under `### String Style`.
- `CHANGELOG.md` — entry under `[Unreleased]` / `### Fixes`.

## Post-review simplify

A follow-up refactor commit addresses hot-path concerns flagged during review:

- Hoisted the URL base to a module-scope `DEFAULT_URL_BASE` constant.
- Absolute HTTP URLs no longer receive a base argument to `new URL()` since the URL constructor ignores it when the first arg has a scheme.
- Inlined `url.hash` in the template literal and dropped a redundant WHAT-comment.
- Replaced `as any` in the new test fixtures with proper `FormattedColumnValue` / `ColumnStyleItemType` casts.

No behavior change; typecheck + lint + 73 unit tests + 12 E2E tests still green.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 73 unit tests pass (67 existing + 6 new)
- [x] `pnpm e2e` — 12 E2E tests pass (11 existing + 1 new clickthrough spec)
- [x] Manual: dashboard with one clickthrough per URL form; click each and confirm navigation goes to the expected URL