### PR TITLE
feat(clickthrough): resolve Grafana template variables in URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   built-in data links. Plugin macros (`$__cell`, `$__cell_N`, `$__from`,
   etc.) continue to resolve first, so a dashboard variable cannot
   intercept a plugin macro of the same name. `$var`, `${var}`, and
-  `[[var]]` syntaxes all work. Covered by three new unit cases plus an
-  E2E assertion on a provisioned dashboard carrying a constant template
-  variable.
+  `[[var]]` syntaxes all work. Covered by three new unit cases in
+  `src/data/cellRenderer.test.ts`, a new
+  `src/data/createdCellHelpers.test.ts` that pins the mid-layer
+  `ProcessStringValueStyle` forwarding, and an E2E assertion on a
+  provisioned dashboard carrying a constant template variable. While in
+  `DataTablePanel.tsx`, the delegated-handler callbacks bound by PR #292
+  are now typed with `JQuery.TriggeredEvent` so TypeScript no longer
+  resolves to the deprecated `JQueryEventObject` overload of
+  `$.fn.on(...)`.
 
 ### Scaffolding & Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     matching cell that overrides the panel-level class. Applies to any
     `activeStyle` (metric / string / date), so the same knob covers all
     column types.
+- **Clickthrough URLs resolve Grafana dashboard variables**. A clickthrough
+  like `http://example.com/h/$host?x=1` now substitutes the dashboard's
+  `$host` variable into the rendered href, matching the behavior of
+  built-in data links. Plugin macros (`$__cell`, `$__cell_N`, `$__from`,
+  etc.) continue to resolve first, so a dashboard variable cannot
+  intercept a plugin macro of the same name. `$var`, `${var}`, and
+  `[[var]]` syntaxes all work. Covered by three new unit cases plus an
+  E2E assertion on a provisioned dashboard carrying a constant template
+  variable.
 
 ### Scaffolding & Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,18 +22,36 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Clickthrough URLs resolve Grafana dashboard variables**. A clickthrough
   like `http://example.com/h/$host?x=1` now substitutes the dashboard's
   `$host` variable into the rendered href, matching the behavior of
-  built-in data links. Plugin macros (`$__cell`, `$__cell_N`, `$__from`,
-  etc.) continue to resolve first, so a dashboard variable cannot
-  intercept a plugin macro of the same name. `$var`, `${var}`, and
-  `[[var]]` syntaxes all work. Covered by three new unit cases in
-  `src/data/cellRenderer.test.ts`, a new
-  `src/data/createdCellHelpers.test.ts` that pins the mid-layer
-  `ProcessStringValueStyle` forwarding, and an E2E assertion on a
-  provisioned dashboard carrying a constant template variable. While in
-  `DataTablePanel.tsx`, the delegated-handler callbacks bound by PR #292
-  are now typed with `JQuery.TriggeredEvent` so TypeScript no longer
-  resolves to the deprecated `JQueryEventObject` overload of
-  `$.fn.on(...)`.
+  built-in data links. Completes the long-standing `// TODO: allowing
+  template variables would be a great addition` comment in
+  `src/data/cellRenderer.ts`.
+  - **Feature.** `ProcessClickthrough` runs `replaceVariables(clickThrough)`
+    immediately after the plugin's `ReplaceCellMacros` pass and before
+    sanitize / URL rebuild. Guarded by `/[$\[]/.test(clickThrough)` so
+    URLs without template markers short-circuit the call on the
+    per-cell hot path.
+  - **Syntax & precedence.** `$var`, `${var}`, and `[[var]]` all resolve.
+    Plugin macros (`$__cell`, `$__cell_N`, `$__pattern_N`, `$__from`,
+    `$__to`, `$__keepTime`) run first, so a dashboard variable named
+    identically to a plugin macro cannot intercept the plugin's
+    substitution.
+  - **Plumbing.** A new `replaceVariables: InterpolateFunction` parameter
+    is threaded from `PanelProps` in `DataTablePanel.tsx` through
+    `BuildColumnDefs`, `ProcessStringValueStyle`, and
+    `ProcessClickthrough`.
+  - **Tests.** Three new unit cases in `src/data/cellRenderer.test.ts`
+    (substitution, guard, precedence); a new
+    `src/data/createdCellHelpers.test.ts` pinning the mid-layer
+    `ProcessStringValueStyle` forwarding; and an E2E assertion in
+    `tests/phase3-panel/clickthrough-urls.spec.ts` against a provisioned
+    dashboard carrying a constant `$host = web-42` template variable.
+  - **Docs.** README `#### Supported URL Formats` subsection extended
+    with the three template-variable syntaxes and the precedence rule.
+  - **Ancillary (type hygiene).** The delegated jQuery handlers bound
+    in `DataTablePanel.tsx` by PR #292 are now typed with
+    `JQuery.TriggeredEvent` so TypeScript resolves to the current
+    `$.fn.on(...)` overload instead of the deprecated
+    `JQueryEventObject` one.
 
 ### Scaffolding & Configuration
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ Additional you can specify if the URL should be open in a new tab or new window,
 Macros (`$__cell_N`, `$__pattern_N`, `$__from`, `$__to`, `$__keepTime`) are expanded before the
 href is constructed, so they work identically in absolute and relative URLs.
 
+Grafana dashboard template variables — `$var`, `${var}`, and `[[var]]` — are
+also supported in clickthrough URLs and resolve via the standard
+`replaceVariables` pipeline. Plugin macros run first; dashboard variables
+resolve on whatever remains, so a dashboard variable named identically to
+a plugin macro (e.g. `$__cell`) cannot intercept the plugin's
+substitution.
+
 #### Pattern Macros
 
 `Split By RegEx` - the cell content of the matching column is split by this regex which can then be used within the URL.

--- a/provisioning/dashboards/dashboards/Datatable-Clickthrough.json
+++ b/provisioning/dashboards/dashboards/Datatable-Clickthrough.json
@@ -99,6 +99,33 @@
               "clickThroughSanitize": false,
               "splitByPattern": ""
             }
+          },
+          {
+            "activeStyle": "string",
+            "dateStyle": {
+              "dateFormat": "YYYY-MM-DD HH:mm:ss"
+            },
+            "enabled": true,
+            "hiddenStyle": {},
+            "label": "LinkWithVar-Template",
+            "metricStyle": {
+              "alias": "",
+              "colorMode": "disabled",
+              "colors": ["#299c46", "#ed8128", "#f53636", "#0a55a1"],
+              "decimals": "2",
+              "ignoreNullValues": true,
+              "thresholds": [],
+              "unitFormat": "short"
+            },
+            "nameOrRegex": "LinkWithVar",
+            "stringStyle": {
+              "clickThrough": "http://example.com/h/$host?cell=$__cell",
+              "clickThroughCustomTarget": "",
+              "clickThroughCustomTargetEnabled": false,
+              "clickThroughOpenNewTab": true,
+              "clickThroughSanitize": false,
+              "splitByPattern": ""
+            }
           }
         ],
         "columnWidthHints": [],
@@ -125,7 +152,7 @@
       "pluginVersion": "2.0.2",
       "targets": [
         {
-          "csvContent": "Host,Dashboard\nweb-01,overview\nweb-02,hosts\nweb-03,services",
+          "csvContent": "Host,Dashboard,LinkWithVar\nweb-01,overview,alpha\nweb-02,hosts,bravo\nweb-03,services,charlie",
           "datasource": {
             "type": "grafana-testdata-datasource",
             "uid": "P53465F745837BCFD"
@@ -142,7 +169,27 @@
   "schemaVersion": 41,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "web-42",
+          "value": "web-42"
+        },
+        "hide": 2,
+        "label": "",
+        "name": "host",
+        "options": [
+          {
+            "selected": true,
+            "text": "web-42",
+            "value": "web-42"
+          }
+        ],
+        "query": "web-42",
+        "type": "constant"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -128,11 +128,11 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     const $container = $(dataTable.table(0).container());
     const debounceTimers = new Map<number, ReturnType<typeof setTimeout>>();
 
-    $container.on('click.columnFilter', 'tr.column-filter th', function (ev) {
+    $container.on('click.columnFilter', 'tr.column-filter th', function (ev: JQuery.TriggeredEvent) {
       ev.stopPropagation();
     });
 
-    $container.on('keyup.columnFilter change.columnFilter', 'input.column-filter', function (this: HTMLInputElement) {
+    $container.on('keyup.columnFilter change.columnFilter', 'input.column-filter', function (this: HTMLInputElement, _ev: JQuery.TriggeredEvent) {
       const columnIndex = $(this).closest('th').index();
       const value = this.value;
       const existing = debounceTimers.get(columnIndex);

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -197,6 +197,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
         props.options.fontSizePercent,
         alignment,
         props.timeRange,
+        props.replaceVariables,
         cachedProcessedData);
       setCachedColumnDefs(calcColumnDefs);
     }
@@ -204,6 +205,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     alignment,
     cachedProcessedData,
     props.timeRange,
+    props.replaceVariables,
     props.options.emptyDataEnabled,
     props.options.emptyDataText,
     props.options.fontSizePercent,

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -155,7 +155,9 @@ describe('Cell Renderer', () => {
 
     const processedItem = { valueFormatted: 'cellText' } as FormattedColumnValue;
 
-    const run = (clickThrough: string) =>
+    const noopReplaceVariables = (s: string) => s;
+
+    const run = (clickThrough: string, replaceVariables: (s: string) => string = noopReplaceVariables) =>
       ProcessClickthrough(
         { stringStyle: { ...baseStringStyle, clickThrough } } as unknown as ColumnStyleItemType,
         /* columns */ [],
@@ -163,6 +165,7 @@ describe('Cell Renderer', () => {
         /* rowIndex */ 0,
         processedItem,
         fakeTimeRange,
+        replaceVariables,
       );
 
     it.each([
@@ -199,6 +202,30 @@ describe('Cell Renderer', () => {
     ])('$label', ({ input, expected }) => {
       const html = run(input);
       expect(html).toContain(expected);
+    });
+
+    it('substitutes dashboard variables after plugin macros', () => {
+      const replaceVariables = (s: string) => s.replace(/\$host/g, 'web-01');
+      const html = run('http://example.com/h/$host?cell=$__cell', replaceVariables);
+      expect(html).toContain('href="http://example.com/h/web-01?cell=cellText"');
+    });
+
+    it('guard skips replaceVariables when no template markers remain', () => {
+      const calls: string[] = [];
+      const replaceVariables = (s: string) => {
+        calls.push(s);
+        return s;
+      };
+      run('http://example.com/plain', replaceVariables);
+      expect(calls).toEqual([]);
+    });
+
+    it('plugin macros take precedence over colliding dashboard variables', () => {
+      // $__cell is a plugin macro — it resolves BEFORE replaceVariables sees it
+      const replaceVariables = (s: string) => s.replace('$__cell', 'INTERCEPTED');
+      const html = run('http://example.com/x?v=$__cell', replaceVariables);
+      expect(html).toContain('href="http://example.com/x?v=cellText"');
+      expect(html).not.toContain('INTERCEPTED');
     });
   });
 });

--- a/src/data/cellRenderer.ts
+++ b/src/data/cellRenderer.ts
@@ -3,6 +3,7 @@ import {
   Field,
   getValueFormat,
   GrafanaTheme2,
+  InterpolateFunction,
   stringToJsRegex,
   textUtil,
   TimeRange,
@@ -168,7 +169,8 @@ export const ProcessClickthrough = (
   rows: any,
   rowIndex: number,
   processedItem: FormattedColumnValue,
-  timeRange: TimeRange) => {
+  timeRange: TimeRange,
+  replaceVariables: InterpolateFunction) => {
 
   if (columnStyle?.stringStyle.clickThrough) {
     let clickThrough = ReplaceTimeMacros(timeRange, columnStyle.stringStyle.clickThrough);
@@ -176,6 +178,13 @@ export const ProcessClickthrough = (
       clickThrough = ReplaceCellSplitByPattern(clickThrough, processedItem, columnStyle.stringStyle.splitByPattern)
     }
     clickThrough = ReplaceCellMacros(clickThrough, processedItem.valueFormatted, rows);
+    // Resolve Grafana dashboard template variables. Runs AFTER plugin
+    // macros so built-ins like $__cell, $__cell_N, $__pattern_N,
+    // $__from, $__to, $__keepTime keep precedence. Guarded on the
+    // presence of a `$` or `[` so clean URLs short-circuit the call.
+    if (/[$\[]/.test(clickThrough)) {
+      clickThrough = replaceVariables(clickThrough);
+    }
     //
     const target = resolveClickThroughTarget(
       columnStyle.stringStyle.clickThroughOpenNewTab,
@@ -213,8 +222,6 @@ export const ProcessClickthrough = (
     }
     const newCell = '<a href="' + href + `" target="${target}">` + processedItem.valueFormatted + '</a>';
 
-    // TODO: allowing template variables would be a great addition
-    //
     return newCell;
   }
   return null;

--- a/src/data/createdCellHelpers.test.ts
+++ b/src/data/createdCellHelpers.test.ts
@@ -1,0 +1,58 @@
+import { ProcessStringValueStyle } from './createdCellHelpers';
+import { ColumnStyleItemType } from 'components/options/columnstyles/types';
+import { FormattedColumnValue } from './types';
+import { TimeRange, dateTime } from '@grafana/data';
+
+// Covers the plumbing that forwards `replaceVariables` from BuildColumnDefs
+// down into ProcessClickthrough. The actual substitution logic is unit-tested
+// in cellRenderer.test.ts — these tests pin the forwarding so a future
+// refactor that drops the parameter or swaps its position is caught here.
+describe('ProcessStringValueStyle', () => {
+  const fakeTimeRange = {
+    from: dateTime(0),
+    to: dateTime(0),
+    raw: { from: 'now-1h', to: 'now' },
+  } as unknown as TimeRange;
+
+  const processedItem = { valueFormatted: 'cellText' } as FormattedColumnValue;
+
+  const makeStyle = (clickThrough: string): ColumnStyleItemType =>
+    ({
+      stringStyle: {
+        clickThrough,
+        clickThroughOpenNewTab: true,
+        clickThroughCustomTargetEnabled: false,
+        clickThroughCustomTarget: '',
+        clickThroughSanitize: false,
+        splitByPattern: '',
+      },
+    } as unknown as ColumnStyleItemType);
+
+  it('forwards replaceVariables to ProcessClickthrough for substitution', () => {
+    const replaceVariables = (s: string) => s.replace(/\$host/g, 'web-99');
+    const html = ProcessStringValueStyle(
+      makeStyle('http://example.com/h/$host?cell=$__cell'),
+      [],
+      [],
+      0,
+      processedItem,
+      fakeTimeRange,
+      replaceVariables,
+    );
+    expect(html).toContain('href="http://example.com/h/web-99?cell=cellText"');
+  });
+
+  it('returns null when the column style has no clickThrough configured', () => {
+    const replaceVariables = (s: string) => s;
+    const html = ProcessStringValueStyle(
+      makeStyle(''),
+      [],
+      [],
+      0,
+      processedItem,
+      fakeTimeRange,
+      replaceVariables,
+    );
+    expect(html).toBeNull();
+  });
+});

--- a/src/data/createdCellHelpers.ts
+++ b/src/data/createdCellHelpers.ts
@@ -3,7 +3,7 @@ import { getCellColors } from "./dataHelpers";
 import { DTColumnType, FormattedColumnValue } from "./types";
 import { ProcessClickthrough } from "./cellRenderer";
 import { ColumnStyleItemType, ColumnStyles } from "components/options/columnstyles/types";
-import { TimeRange } from "@grafana/data";
+import { InterpolateFunction, TimeRange } from "@grafana/data";
 
 
 export const processRowStyle = (
@@ -128,7 +128,8 @@ export const ProcessStringValueStyle = (
   rowData: any,
   rowIndex: number,
   valueFormatted: FormattedColumnValue,
-  timeRange: TimeRange): string | null => {
+  timeRange: TimeRange,
+  replaceVariables: InterpolateFunction): string | null => {
 
   const processedURL = ProcessClickthrough(
     columnStyle,
@@ -136,7 +137,8 @@ export const ProcessStringValueStyle = (
     rowData,
     rowIndex,
     valueFormatted,
-    timeRange);
+    timeRange,
+    replaceVariables);
   if (processedURL !== undefined) {
     return processedURL;
   }

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -5,6 +5,7 @@ import {
   FieldConfigSource,
   FieldType,
   GrafanaTheme2,
+  InterpolateFunction,
   TimeRange
 } from '@grafana/data';
 import { FormatColumnValue } from 'data/cellRenderer';
@@ -152,6 +153,7 @@ export const BuildColumnDefs = (
   fontSizePercent: string,
   alignment: AlignmentFlags,
   timeRange: TimeRange,
+  replaceVariables: InterpolateFunction,
   dtData: DTData): ConfigColumnDefs[] => {
 
   const columnDefs: ConfigColumnDefs[] = [];
@@ -275,7 +277,9 @@ export const BuildColumnDefs = (
             rowData,
             rowIndex,
             cellValueFormatted,
-            timeRange);
+            timeRange,
+            replaceVariables,
+          );
           if (newCell !== null) {
             $(cell).html(newCell);
           }

--- a/tests/phase3-panel/clickthrough-urls.spec.ts
+++ b/tests/phase3-panel/clickthrough-urls.spec.ts
@@ -57,5 +57,14 @@ test.describe('clickthrough URL rendering (issue #276)', () => {
         '/d/uid/hosts',
       );
     });
+
+    await test.step('dashboard template variable $host is resolved in the rendered href', async () => {
+      const hostLink = firstRow.locator('td a').nth(2);
+      await expect(hostLink).toHaveText('alpha');
+      await expect(hostLink).toHaveAttribute(
+        'href',
+        'http://example.com/h/web-42?cell=alpha',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

Completes the `// TODO: allowing template variables would be a great addition` comment that remained in `src/data/cellRenderer.ts` after PR #293. Clickthrough URLs now resolve Grafana dashboard template variables via `props.replaceVariables` — `$var`, `${var}`, and `[[var]]` syntaxes all work, plugin macros still take precedence, and a cheap regex guard short-circuits URLs with no template markers.

## Feature

- **`src/data/cellRenderer.ts`** — `ProcessClickthrough` now runs `replaceVariables(clickThrough)` immediately after `ReplaceCellMacros` and before `sanitize` / URL rebuild. Guarded by `if (/[$\[]/.test(clickThrough))` so clean URLs skip the call entirely. The stale `// TODO: allowing template variables would be a great addition` comment is gone.

## Plumbing (threading `replaceVariables: InterpolateFunction`)

- **`src/components/DataTablePanel.tsx`** — passes `props.replaceVariables` into `BuildColumnDefs` and adds it to the effect dep array.
- **`src/data/dataHelpers.ts`** — `BuildColumnDefs` signature gains the new parameter between `timeRange` and `dtData`; forwards it to `ProcessStringValueStyle`.
- **`src/data/createdCellHelpers.ts`** — `ProcessStringValueStyle` signature gains the new parameter at the end; forwards it to `ProcessClickthrough`.

## Tests

- **`src/data/cellRenderer.test.ts`** — three new `it(...)` cases inside the existing `ProcessClickthrough` describe:
  - substitution works after plugin macros
  - guard short-circuits clean URLs (spy asserts `replaceVariables` was never called)
  - plugin macros take precedence on name collisions (`$__cell` resolves via the plugin first, so a dashboard variable of the same name can't intercept it)
- **`src/data/createdCellHelpers.test.ts` (new)** — pins the mid-layer forwarding with two cases: substitution flows end-to-end, `null` returns when no clickthrough is configured.
- **`tests/phase3-panel/clickthrough-urls.spec.ts`** + **`provisioning/dashboards/dashboards/Datatable-Clickthrough.json`** — dashboard gains a constant `$host = web-42` variable and a third column whose clickthrough is `http://example.com/h/$host?cell=$__cell`. New `test.step` asserts the rendered row-1 href is exactly `http://example.com/h/web-42?cell=alpha`, proving both substitution AND that plugin macros still expand alongside.

## Docs

- **`README.md`** — appends a paragraph to the existing `#### Supported URL Formats` subsection documenting the three template-variable syntaxes and the plugin-macros-win precedence rule.
- **`CHANGELOG.md`** — entry under `## [Unreleased]` → `### Added`.

## Ancillary

- **`src/components/DataTablePanel.tsx`** — the two PR #292 delegated jQuery handlers (`$container.on('click...')` + `$container.on('keyup change...')`) are now annotated with `JQuery.TriggeredEvent`, which selects the current `$.fn.on(...)` overload and clears the `no-deprecated` TypeScript warning for `JQueryEventObject`.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 78 unit tests pass (73 existing + 3 in `cellRenderer.test.ts` + 2 in `createdCellHelpers.test.ts`)
- [x] `pnpm e2e` — 12 E2E tests pass (11 existing + 1 new step inside the clickthrough spec)
- [x] Manual: verified in-browser that `$host` in a clickthrough resolves to the dashboard's variable value