### PR TITLE
refactor(transformations): remove stale @ts-ignore + add unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,43 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   covering field-to-column shape mapping, row-object build, the
   `rowNumbersEnabled` branch (prepend `row` column + stamp indices),
   and the HIDDEN-style visibility toggle.
+- Convert `ConvertDataFrameToDataTableFormat` (`src/data/dataHelpers.ts`)
+  from 9 positional arguments to a `ConvertDataFrameOptions` object.
+  The call site in `DataTablePanel.tsx` is now self-documenting at the
+  named-argument level. Also drops the unused `timeRange` parameter
+  that the prior signature carried but the function body never read.
+- Convert `BuildColumnDefs` (`src/data/dataHelpers.ts`) from 6
+  positional arguments to a `BuildColumnDefsOptions` object, matching
+  the `ConvertDataFrameOptions` precedent so the two sibling helpers
+  share the same call shape. Covered by a new `BuildColumnDefs` unit
+  test that pins the options-object API and the
+  `{ targets: '_all', defaultContent: '-' }` sentinel that
+  DataTables relies on to suppress a dialog when toggling the
+  row-number column at runtime.
+- `getCellColors` (`src/data/dataHelpers.ts`) drops its unused
+  `columnNumber` parameter (3 call sites + 7 test sites updated). The
+  `createdCell` helper's `actualColumn = colIndex - rowNumbersEnabled
+  ? 1 : 0` offset fed only that now-removed parameter, so it was dead
+  too and has been removed with it.
+- Drop unused `emptyDataEnabled` / `emptyDataText` parameters from
+  `BuildColumnDefs`. The options never had a runtime consumer — the
+  commented-out `defaultContent: emptyDataEnabled ? emptyDataText : ''`
+  reference was the only code that had ever read them, and wiring it
+  up turned out to conflict with the existing render pipeline. The
+  options are still surfaced in the editor and preserved by migration
+  for now; the architectural mismatch and remediation options are
+  tracked in
+  [#296](https://github.com/briangann/grafana-datatable-panel/issues/296).
+- Rename unused positional parameters in the DataTables `data:` /
+  `render:` column-def callbacks to the `_`-prefixed convention
+  (`_set`, `_data`) so the `@typescript-eslint/no-unused-vars` check
+  passes without a suppress comment while preserving the
+  library-dictated positional signatures.
+- Block-scope the `case` bodies in
+  `src/data/valueMappings.ts:getValueMappingResult` that declare
+  `const` identifiers. Fixes the `no-case-declarations` style
+  concern for the `ValueToText`, `RangeToText`, and `RegexToText`
+  cases.
 - Add `src/hooks/useTracker.ts`: a typed, immutable `useTracker<Item, Payload>` hook
   encapsulating the ordered-tracker-with-onChange-fan-out pattern used by
   `ThresholdsEditor` and `ColumnStylesEditor`. Exposes `items`, `setAll`, `add`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   picks up the real interpolator too, so Grafana dashboard variables
   referenced inside field-config defaults resolve identically to the
   stock link/threshold pipelines.
+- Add the missing `break;` after `case MappingType.RegexToText:` in
+  `src/data/valueMappings.ts:getValueMappingResult`. The previous code
+  fell through into `case MappingType.SpecialValue:` when a regex did
+  not match — latent (the inner switch's `match` discriminant is
+  `undefined` on a RegexToText options object, so every `SpecialValue`
+  sub-case was a no-op in practice) but fragile. Pinned with a new
+  regression test that confirms the iteration continues cleanly to the
+  next mapping after a non-matching regex.
 - Add `src/hooks/useTracker.ts`: a typed, immutable `useTracker<Item, Payload>` hook
   encapsulating the ordered-tracker-with-onChange-fan-out pattern used by
   `ThresholdsEditor` and `ColumnStylesEditor`. Exposes `items`, `setAll`, `add`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   sub-case was a no-op in practice) but fragile. Pinned with a new
   regression test that confirms the iteration continues cleanly to the
   next mapping after a non-matching regex.
+- Fix `TimeFormatter` in `src/data/cellRenderer.ts` for non-UTC
+  timezones. The function used `moment.tz(iso, format, tz)` — the
+  parsing overload, which treats `iso` as already-local-to-tz — so the
+  output was the UTC time digits labeled as the target zone. A
+  dashboard in `America/New_York` at 15:27:35 EDT would render as
+  `19:27:35` (the UTC digits). Switched to the conversion overload
+  `moment.tz(ms, tz)`, which takes a UTC-millis timestamp and returns
+  the corresponding Moment in the target zone; also removed a dead
+  `let formattedWithTimezone = dateTime(...)` initialiser that was
+  unconditionally overwritten on the next line. `TimeFormatter`'s unit
+  test now pins a real UTC→EDT conversion instead of the prior
+  shape-only assertion.
 - Raise `src/data/` unit-test coverage from 44% to 60% by adding tests
   for `columnAliasing.ts` (7 cases), `columnWidthHints.ts` (7 cases),
   the previously-untested helpers in `cellRenderer.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Refactoring
 
+- Remove a stale `// @ts-ignore` + `TODO: fix this ignore, it works but should not be
+  required` in `src/data/transformations.ts:transformData`. The ignore was covering
+  a type mismatch between `lastValueFrom` and the `Observable<DataFrame[]>` returned
+  by `transformDataFrame`; current `@grafana/data` / `rxjs` versions align
+  (both resolve to `rxjs@7.8.2`) so the call typechecks cleanly now.
 - Add `src/hooks/useTracker.ts`: a typed, immutable `useTracker<Item, Payload>` hook
   encapsulating the ordered-tracker-with-onChange-fan-out pattern used by
   `ThresholdsEditor` and `ColumnStylesEditor`. Exposes `items`, `setAll`, `add`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,32 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `const` identifiers. Fixes the `no-case-declarations` style
   concern for the `ValueToText`, `RangeToText`, and `RegexToText`
   cases.
+- Factor the repeated `as unknown as Record<string, unknown>` cast in
+  the `BuildColumnDefs` unit test (`src/data/dataHelpers.test.ts`)
+  into a single `asRecord(d)` helper scoped to the describe block.
+  DataTables' `ConfigColumnDefs` is a narrow union with no index
+  signature, so probing runtime properties needs the bounce through
+  `unknown`; the helper keeps the test assertions grep-able.
+- Sharpen the no-work short-circuit assertion in
+  `src/data/overrides.test.ts`. The previous
+  `expect(Array.isArray(calls)).toBe(true)` was tautological (the
+  array was declared as `[]` in scope). Replaced with
+  `expect(calls).toEqual([])` so the test actually pins that
+  `applyFieldOverrides` does not invoke the spy when the
+  `fieldConfig` carries no template syntax.
+- Hoist the reused `1744486055000` timestamp in
+  `src/data/cellRenderer.test.ts` (five occurrences across
+  `FormatColumnValue` and `TimeFormatter` cases) into a single
+  file-scope `EPOCH_2025_04_12T19_27_35Z` constant. The human-readable
+  date now reads off the identifier instead of being inferred from
+  each assertion's `.toBe('2025-04-12 …')`.
+- Keep `props.options.emptyDataEnabled` and `props.options.emptyDataText`
+  in the two `useEffect` dep arrays in
+  `src/components/DataTablePanel.tsx` even though neither effect body
+  reads them today. Added a comment on each site explaining the deps
+  are placeholders for the option-B remediation in #296 that would
+  wire the option into `defaultContent`; when that lands, the effects
+  must re-run on toggle and the deps are already in place.
 - Add `src/hooks/useTracker.ts`: a typed, immutable `useTracker<Item, Payload>` hook
   encapsulating the ordered-tracker-with-onChange-fan-out pattern used by
   `ThresholdsEditor` and `ColumnStylesEditor`. Exposes `items`, `setAll`, `add`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,16 +172,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   unconditionally overwritten on the next line. `TimeFormatter`'s unit
   test now pins a real UTC→EDT conversion instead of the prior
   shape-only assertion.
-- Raise `src/data/` unit-test coverage from 44% to 60% by adding tests
-  for `columnAliasing.ts` (7 cases), `columnWidthHints.ts` (7 cases),
-  the previously-untested helpers in `cellRenderer.ts`
-  (`ReplaceTimeMacros`, `ReplaceCellMacros`, `ReplaceCellSplitByPattern`,
-  `resolveClickThroughTarget`, `TimeFormatter` — 19 cases across five
-  new describe blocks), and the color-threshold helpers in
-  `dataHelpers.ts` (`GetColorForValue`, `GetColorIndexForValue`,
-  `getCellColors` — 25 cases). `dataHelpers.test.ts` earlier covered
-  only `getColumnClassName`; it now exercises the full threshold-colour
-  path plus null/disabled edge cases.
+- Raise `src/data/` unit-test coverage from 44% to 73%. First pass added
+  tests for `columnAliasing.ts` (7 cases), `columnWidthHints.ts` (7
+  cases), and extended `cellRenderer.test.ts` +
+  `dataHelpers.test.ts` with previously-untested helper and
+  threshold-colour paths. Follow-up round closed additional branches:
+  `columnStyles.test.ts` regex-match + exact-match paths, remaining
+  `SpecialValueMatch` sub-case fall-throughs and
+  `RangeToText`/`RegexToText` null-guards in `valueMappings.test.ts`,
+  `FormatColumnValue` paths for string columns, DATE columnStyle
+  custom `dateFormat`, and columnStyle `unitFormat` / `decimals`
+  overrides, `ProcessClickthrough` `splitByPattern` and
+  `clickThroughSanitize` branches, `applyFormat` currency-prefix
+  branch, and four new `ConvertDataFrameToDataTableFormat` cases
+  covering field-to-column shape mapping, row-object build, the
+  `rowNumbersEnabled` branch (prepend `row` column + stamp indices),
+  and the HIDDEN-style visibility toggle.
 - Add `src/hooks/useTracker.ts`: a typed, immutable `useTracker<Item, Payload>` hook
   encapsulating the ordered-tracker-with-onChange-fan-out pattern used by
   `ThresholdsEditor` and `ColumnStylesEditor`. Exposes `items`, `setAll`, `add`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   sub-case was a no-op in practice) but fragile. Pinned with a new
   regression test that confirms the iteration continues cleanly to the
   next mapping after a non-matching regex.
+- Raise `src/data/` unit-test coverage from 44% to 60% by adding tests
+  for `columnAliasing.ts` (7 cases), `columnWidthHints.ts` (7 cases),
+  the previously-untested helpers in `cellRenderer.ts`
+  (`ReplaceTimeMacros`, `ReplaceCellMacros`, `ReplaceCellSplitByPattern`,
+  `resolveClickThroughTarget`, `TimeFormatter` — 19 cases across five
+  new describe blocks), and the color-threshold helpers in
+  `dataHelpers.ts` (`GetColorForValue`, `GetColorIndexForValue`,
+  `getCellColors` — 25 cases). `dataHelpers.test.ts` earlier covered
+  only `getColumnClassName`; it now exercises the full threshold-colour
+  path plus null/disabled edge cases.
 - Add `src/hooks/useTracker.ts`: a typed, immutable `useTracker<Item, Payload>` hook
   encapsulating the ordered-tracker-with-onChange-fan-out pattern used by
   `ThresholdsEditor` and `ColumnStylesEditor`. Exposes `items`, `setAll`, `add`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Refactoring
 
+#### Correctness
+
 - Remove a stale `// @ts-ignore` + `TODO: fix this ignore, it works but should not be
   required` in `src/data/transformations.ts:transformData`. The ignore was covering
   a type mismatch between `lastValueFrom` and the `Observable<DataFrame[]>` returned
@@ -172,6 +174,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   unconditionally overwritten on the next line. `TimeFormatter`'s unit
   test now pins a real UTC→EDT conversion instead of the prior
   shape-only assertion.
+
+#### Test coverage & quality
+
 - Raise `src/data/` unit-test coverage from 44% to 73%. First pass added
   tests for `columnAliasing.ts` (7 cases), `columnWidthHints.ts` (7
   cases), and extended `cellRenderer.test.ts` +
@@ -188,6 +193,28 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   covering field-to-column shape mapping, row-object build, the
   `rowNumbersEnabled` branch (prepend `row` column + stamp indices),
   and the HIDDEN-style visibility toggle.
+- Factor the repeated `as unknown as Record<string, unknown>` cast in
+  the `BuildColumnDefs` unit test (`src/data/dataHelpers.test.ts`)
+  into a single `asRecord(d)` helper scoped to the describe block.
+  DataTables' `ConfigColumnDefs` is a narrow union with no index
+  signature, so probing runtime properties needs the bounce through
+  `unknown`; the helper keeps the test assertions grep-able.
+- Sharpen the no-work short-circuit assertion in
+  `src/data/overrides.test.ts`. The previous
+  `expect(Array.isArray(calls)).toBe(true)` was tautological (the
+  array was declared as `[]` in scope). Replaced with
+  `expect(calls).toEqual([])` so the test actually pins that
+  `applyFieldOverrides` does not invoke the spy when the
+  `fieldConfig` carries no template syntax.
+- Hoist the reused `1744486055000` timestamp in
+  `src/data/cellRenderer.test.ts` (five occurrences across
+  `FormatColumnValue` and `TimeFormatter` cases) into a single
+  file-scope `EPOCH_2025_04_12T19_27_35Z` constant. The human-readable
+  date now reads off the identifier instead of being inferred from
+  each assertion's `.toBe('2025-04-12 …')`.
+
+#### API cleanup
+
 - Convert `ConvertDataFrameToDataTableFormat` (`src/data/dataHelpers.ts`)
   from 9 positional arguments to a `ConvertDataFrameOptions` object.
   The call site in `DataTablePanel.tsx` is now self-documenting at the
@@ -215,6 +242,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   for now; the architectural mismatch and remediation options are
   tracked in
   [#296](https://github.com/briangann/grafana-datatable-panel/issues/296).
+
+#### Style & convention
+
 - Rename unused positional parameters in the DataTables `data:` /
   `render:` column-def callbacks to the `_`-prefixed convention
   (`_set`, `_data`) so the `@typescript-eslint/no-unused-vars` check
@@ -225,25 +255,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `const` identifiers. Fixes the `no-case-declarations` style
   concern for the `ValueToText`, `RangeToText`, and `RegexToText`
   cases.
-- Factor the repeated `as unknown as Record<string, unknown>` cast in
-  the `BuildColumnDefs` unit test (`src/data/dataHelpers.test.ts`)
-  into a single `asRecord(d)` helper scoped to the describe block.
-  DataTables' `ConfigColumnDefs` is a narrow union with no index
-  signature, so probing runtime properties needs the bounce through
-  `unknown`; the helper keeps the test assertions grep-able.
-- Sharpen the no-work short-circuit assertion in
-  `src/data/overrides.test.ts`. The previous
-  `expect(Array.isArray(calls)).toBe(true)` was tautological (the
-  array was declared as `[]` in scope). Replaced with
-  `expect(calls).toEqual([])` so the test actually pins that
-  `applyFieldOverrides` does not invoke the spy when the
-  `fieldConfig` carries no template syntax.
-- Hoist the reused `1744486055000` timestamp in
-  `src/data/cellRenderer.test.ts` (five occurrences across
-  `FormatColumnValue` and `TimeFormatter` cases) into a single
-  file-scope `EPOCH_2025_04_12T19_27_35Z` constant. The human-readable
-  date now reads off the identifier instead of being inferred from
-  each assertion's `.toBe('2025-04-12 …')`.
+
+#### React effects & state
+
 - Keep `props.options.emptyDataEnabled` and `props.options.emptyDataText`
   in the two `useEffect` dep arrays in
   `src/components/DataTablePanel.tsx` even though neither effect body

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   a type mismatch between `lastValueFrom` and the `Observable<DataFrame[]>` returned
   by `transformDataFrame`; current `@grafana/data` / `rxjs` versions align
   (both resolve to `rxjs@7.8.2`) so the call typechecks cleanly now.
+- Wire `props.replaceVariables` into `ApplyGrafanaOverrides`
+  (`src/data/overrides.ts`). The function previously passed a no-op
+  `(value) => value` to `applyFieldOverrides`; now that the panel already
+  threads `replaceVariables` for clickthrough URLs, the override pass
+  picks up the real interpolator too, so Grafana dashboard variables
+  referenced inside field-config defaults resolve identically to the
+  stock link/threshold pipelines.
 - Add `src/hooks/useTracker.ts`: a typed, immutable `useTracker<Item, Payload>` hook
   encapsulating the ordered-tracker-with-onChange-fan-out pattern used by
   `ThresholdsEditor` and `ColumnStylesEditor`. Exposes `items`, `setAll`, `add`,

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = "24.14.1"
+node = { version = "24.14.1", postinstall = "corepack enable" }

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -228,7 +228,8 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
           alignment,
           props.options.rowNumbersEnabled,
           props.options.columnStylesConfig,
-          theme2);
+          theme2,
+          props.replaceVariables);
         dtColumns = result.columns;
         // get the column widths
         dtColumns = ApplyColumnWidthHints(dtColumns, props.options.columnWidthHints);
@@ -247,6 +248,7 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     props.fieldConfig,
     props.timeZone,
     props.timeRange,
+    props.replaceVariables,
     props.data.state,
     props.data.series,
     props.options.columnAliases,

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -190,13 +190,14 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
 
   useEffect(() => {
     if (cachedProcessedData !== undefined) {
-      const calcColumnDefs = BuildColumnDefs(
-        props.options.rowNumbersEnabled,
-        props.options.fontSizePercent,
+      const calcColumnDefs = BuildColumnDefs({
+        rowNumbersEnabled: props.options.rowNumbersEnabled,
+        fontSizePercent: props.options.fontSizePercent,
         alignment,
-        props.timeRange,
-        props.replaceVariables,
-        cachedProcessedData);
+        timeRange: props.timeRange,
+        replaceVariables: props.replaceVariables,
+        dtData: cachedProcessedData,
+      });
       setCachedColumnDefs(calcColumnDefs);
     }
   }, [

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -191,8 +191,6 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
   useEffect(() => {
     if (cachedProcessedData !== undefined) {
       const calcColumnDefs = BuildColumnDefs(
-        props.options.emptyDataEnabled,
-        props.options.emptyDataText,
         props.options.rowNumbersEnabled,
         props.options.fontSizePercent,
         alignment,
@@ -206,8 +204,6 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     cachedProcessedData,
     props.timeRange,
     props.replaceVariables,
-    props.options.emptyDataEnabled,
-    props.options.emptyDataText,
     props.options.fontSizePercent,
     props.options.rowNumbersEnabled]);
 
@@ -220,16 +216,16 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
 
         let dtColumns: DTColumnType[] = [];
         let flattenedRows: any[] = [];
-        const result = ConvertDataFrameToDataTableFormat(
+        const result = ConvertDataFrameToDataTableFormat({
           dataFrames,
-          props.fieldConfig,
-          props.timeZone,
-          props.timeRange,
+          fieldConfig: props.fieldConfig,
+          userTimeZone: props.timeZone,
           alignment,
-          props.options.rowNumbersEnabled,
-          props.options.columnStylesConfig,
-          theme2,
-          props.replaceVariables);
+          rowNumbersEnabled: props.options.rowNumbersEnabled,
+          columnStyles: props.options.columnStylesConfig,
+          theme: theme2,
+          replaceVariables: props.replaceVariables,
+        });
         dtColumns = result.columns;
         // get the column widths
         dtColumns = ApplyColumnWidthHints(dtColumns, props.options.columnWidthHints);

--- a/src/components/DataTablePanel.tsx
+++ b/src/components/DataTablePanel.tsx
@@ -251,6 +251,11 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     props.options.columnAliases,
     props.options.columnStylesConfig,
     props.options.columnWidthHints,
+    // emptyDataEnabled / emptyDataText are currently unreachable at runtime
+    // (see #296), so neither effect body reads them today. Kept in the deps
+    // array as a placeholder for the option-B remediation that wires the
+    // option into defaultContent — when that lands, this effect WILL need
+    // to re-run on toggle, and the dep is ready to carry that change.
     props.options.emptyDataEnabled,
     props.options.emptyDataText,
     props.options.fontSizePercent,
@@ -373,6 +378,9 @@ export const DataTablePanel: React.FC<Props> = (props: Props) => {
     props.options.columnStylesConfig,
     props.options.columnWidthHints,
     props.options.datatablePagingType,
+    // See the equivalent comment on the BuildColumnDefs effect above — kept
+    // in deps for the #296 option-B path that would make this effect sensitive
+    // to emptyData toggles via the re-init chain through cachedColumnDefs.
     props.options.emptyDataEnabled,
     props.options.emptyDataText,
     props.options.fontSizePercent,

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -15,6 +15,11 @@ import {
 import { Field, FieldConfig, FieldType, GrafanaTheme2, TimeRange, dateTime} from '@grafana/data';
 import { FormattedColumnValue } from './types';
 import { ColumnStyleItemType, ColumnStyles } from 'components/options/columnstyles/types';
+// Single reference epoch reused across FormatColumnValue / TimeFormatter
+// cases so the human-readable date is declared once at the top of the file
+// instead of inferred from each assertion's `.toBe('2025-04-12 …')`.
+const EPOCH_2025_04_12T19_27_35Z = 1744486055000;
+
 describe('Cell Renderer', () => {
   const theme2 = {} as unknown as GrafanaTheme2;
   describe('Test FormatColumnValue', () => {
@@ -32,7 +37,7 @@ describe('Cell Renderer', () => {
           aField,
           1,
           0,
-          1744486055000,
+          EPOCH_2025_04_12T19_27_35Z,
           'time',
           theme2,
         );
@@ -96,7 +101,7 @@ describe('Cell Renderer', () => {
         dateStyle: { dateFormat: 'YYYY/MM/DD' },
       } as unknown as ColumnStyleItemType;
       it('uses the columnStyle date format when present', () => {
-        const result = FormatColumnValue('utc', dateStyle, aField, 0, 0, 1744486055000, 'time', {} as GrafanaTheme2);
+        const result = FormatColumnValue('utc', dateStyle, aField, 0, 0, EPOCH_2025_04_12T19_27_35Z, 'time', {} as GrafanaTheme2);
         expect(result.valueFormatted).toBe('2025/04/12');
       });
     });
@@ -148,11 +153,11 @@ describe('Cell Renderer', () => {
 
   describe('Test TimeFormatter', () => {
     describe('Test numeric to UTC formatting', () => {
-      const result = TimeFormatter('utc', 1744486055000, DateFormats[5].value);
+      const result = TimeFormatter('utc', EPOCH_2025_04_12T19_27_35Z, DateFormats[5].value);
       expect(result.valueFormatted).toEqual('2025-04-12T19:27:35+00:00');
     });
     describe('Test numeric to America/Denver formatting', () => {
-      const result = TimeFormatter('America/Denver', 1744486055000, 'YYYY-MM-DDTHH:mm:ssZ');
+      const result = TimeFormatter('America/Denver', EPOCH_2025_04_12T19_27_35Z, 'YYYY-MM-DDTHH:mm:ssZ');
       expect(result.valueFormatted).toEqual('2025-04-12T13:27:35-06:00');
     });
   });
@@ -460,7 +465,7 @@ describe('Cell Renderer', () => {
   });
 
   describe('TimeFormatter', () => {
-    const epoch = 1744486055000; // 2025-04-12T19:27:35Z
+    const epoch = EPOCH_2025_04_12T19_27_35Z;
 
     it('formats a timestamp in UTC when timeZone is "utc"', () => {
       const result = TimeFormatter('utc', epoch, 'YYYY-MM-DD HH:mm:ss');

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -14,7 +14,7 @@ import {
 } from './cellRenderer';
 import { Field, FieldConfig, FieldType, GrafanaTheme2, TimeRange, dateTime} from '@grafana/data';
 import { FormattedColumnValue } from './types';
-import { ColumnStyleItemType } from 'components/options/columnstyles/types';
+import { ColumnStyleItemType, ColumnStyles } from 'components/options/columnstyles/types';
 describe('Cell Renderer', () => {
   const theme2 = {} as unknown as GrafanaTheme2;
   describe('Test FormatColumnValue', () => {
@@ -63,6 +63,60 @@ describe('Cell Renderer', () => {
         );
         // show just return a string with the value inside
         expect(result.valueFormatted).toEqual('123.456');
+      });
+    });
+
+    describe('with a string column', () => {
+      const aField: Field = {
+        name: '',
+        type: FieldType.string,
+        config: [] as FieldConfig,
+        values: [],
+      };
+      it('passes the string value through unchanged', () => {
+        const result = FormatColumnValue('utc', null, aField, 0, 0, 'hello', 'string', {} as GrafanaTheme2);
+        expect(result).toEqual({
+          valueRaw: 'hello',
+          valueFormatted: 'hello',
+          valueRounded: null,
+          valueRoundedAndFormatted: null,
+        });
+      });
+    });
+
+    describe('with a DATE columnStyle and custom dateFormat', () => {
+      const aField: Field = {
+        name: '',
+        type: FieldType.time,
+        config: [] as FieldConfig,
+        values: [],
+      };
+      const dateStyle = {
+        activeStyle: ColumnStyles.DATE,
+        dateStyle: { dateFormat: 'YYYY/MM/DD' },
+      } as unknown as ColumnStyleItemType;
+      it('uses the columnStyle date format when present', () => {
+        const result = FormatColumnValue('utc', dateStyle, aField, 0, 0, 1744486055000, 'time', {} as GrafanaTheme2);
+        expect(result.valueFormatted).toBe('2025/04/12');
+      });
+    });
+
+    describe('with columnStyle metric overrides', () => {
+      const aField: Field = {
+        name: '',
+        type: FieldType.number,
+        config: { unit: 'kwh', decimals: 3 } as FieldConfig,
+        values: [],
+      };
+      const metricStyle = {
+        activeStyle: ColumnStyles.METRIC,
+        metricStyle: { unitFormat: 'percentunit', decimals: '1' },
+      } as unknown as ColumnStyleItemType;
+
+      it('columnStyle unit/decimals override the field config', () => {
+        const result = FormatColumnValue('utc', metricStyle, aField, 0, 0, 0.5, 'number', {} as GrafanaTheme2);
+        // percentunit 0.5 at 1 decimal → "50.0%"
+        expect(result.valueFormatted).toBe('50.0%');
       });
     });
 
@@ -141,6 +195,14 @@ describe('Cell Renderer', () => {
       expect(result.valueFormatted).toEqual('123.46 kwh');
       expect(result.valueRounded).toEqual(123.46);
       expect(result.valueRoundedAndFormatted).toEqual('123.46 kwh');
+    });
+
+    it('prepends the prefix for currency formats', () => {
+      // currencyUSD has a '$' prefix — exercises the `formatted.prefix`
+      // branch that concatenates before the value.
+      const result = applyFormat(12.34, 2, 'currencyUSD');
+      expect(result.valueFormatted.startsWith('$')).toBe(true);
+      expect(result.valueFormatted).toContain('12.34');
     });
   });
 
@@ -235,6 +297,50 @@ describe('Cell Renderer', () => {
       const html = run('http://example.com/x?v=$__cell', replaceVariables);
       expect(html).toContain('href="http://example.com/x?v=cellText"');
       expect(html).not.toContain('INTERCEPTED');
+    });
+
+    it('splits the cell value by splitByPattern and expands $__pattern_N', () => {
+      const style = {
+        stringStyle: {
+          ...baseStringStyle,
+          clickThrough: 'http://example.com/?host=$__pattern_0&env=$__pattern_1',
+          splitByPattern: '/\\s/',
+        },
+      } as unknown as ColumnStyleItemType;
+      const html = ProcessClickthrough(
+        style,
+        [],
+        [],
+        0,
+        { valueFormatted: 'web-01 prod' } as FormattedColumnValue,
+        fakeTimeRange,
+        noopReplaceVariables,
+      );
+      expect(html).toContain('href="http://example.com/?host=web-01&env=prod"');
+    });
+
+    it('sanitizes the URL when clickThroughSanitize is enabled', () => {
+      // `textUtil.sanitizeUrl` strips known-dangerous schemes; here we
+      // just assert the sanitize branch runs without throwing by
+      // feeding a normal URL. Changed behaviour (scheme stripping) is
+      // owned by @grafana/data and isn't re-tested at this layer.
+      const style = {
+        stringStyle: {
+          ...baseStringStyle,
+          clickThrough: 'http://example.com/x',
+          clickThroughSanitize: true,
+        },
+      } as unknown as ColumnStyleItemType;
+      const html = ProcessClickthrough(
+        style,
+        [],
+        [],
+        0,
+        { valueFormatted: 'cell' } as FormattedColumnValue,
+        fakeTimeRange,
+        noopReplaceVariables,
+      );
+      expect(html).toContain('href="http://example.com/x"');
     });
   });
 

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -15,7 +15,6 @@ import {
 import { Field, FieldConfig, FieldType, GrafanaTheme2, TimeRange, dateTime} from '@grafana/data';
 import { FormattedColumnValue } from './types';
 import { ColumnStyleItemType } from 'components/options/columnstyles/types';
-import { FormattedColumnValue } from './types';
 describe('Cell Renderer', () => {
   const theme2 = {} as unknown as GrafanaTheme2;
   describe('Test FormatColumnValue', () => {
@@ -365,17 +364,18 @@ describe('Cell Renderer', () => {
       expect(result.valueRounded).toBeNull();
     });
 
-    it('returns a FormattedColumnValue for a named zone (shape only)', () => {
-      // Non-UTC branch does not actually convert to the named zone — it
-      // passes the already-UTC moment through moment.tz with `format`
-      // + `timezone` args, which produces the UTC time string under a
-      // different label. Pinning that shape is still useful: the function
-      // returns a well-formed FormattedColumnValue rather than throwing.
+    it('converts the timestamp to the named zone (UTC-4 EDT in April)', () => {
       const result = TimeFormatter('America/New_York', epoch, 'YYYY-MM-DD HH:mm:ss');
       expect(result.valueRaw).toBe(epoch);
-      expect(typeof result.valueFormatted).toBe('string');
+      expect(result.valueFormatted).toBe('2025-04-12 15:27:35');
+      expect(result.valueRoundedAndFormatted).toBe(result.valueFormatted);
+    });
+
+    it('resolves "browser" to the host system zone', () => {
+      // Can only assert shape here — the CI runner's zone is not pinned.
+      const result = TimeFormatter('browser', epoch, 'YYYY-MM-DD HH:mm:ss');
+      expect(result.valueRaw).toBe(epoch);
       expect(result.valueFormatted).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
-      expect(result.valueRounded).toBeNull();
     });
   });
 });

--- a/src/data/cellRenderer.test.ts
+++ b/src/data/cellRenderer.test.ts
@@ -2,8 +2,18 @@
  * Tests for Rendering a Cell
  */
 import { DateFormats } from 'types';
-import { applyFormat, FormatColumnValue, ProcessClickthrough, ReplaceTimeMacros, TimeFormatter } from './cellRenderer';
+import {
+  applyFormat,
+  FormatColumnValue,
+  ProcessClickthrough,
+  ReplaceCellMacros,
+  ReplaceCellSplitByPattern,
+  ReplaceTimeMacros,
+  resolveClickThroughTarget,
+  TimeFormatter,
+} from './cellRenderer';
 import { Field, FieldConfig, FieldType, GrafanaTheme2, TimeRange, dateTime} from '@grafana/data';
+import { FormattedColumnValue } from './types';
 import { ColumnStyleItemType } from 'components/options/columnstyles/types';
 import { FormattedColumnValue } from './types';
 describe('Cell Renderer', () => {
@@ -226,6 +236,146 @@ describe('Cell Renderer', () => {
       const html = run('http://example.com/x?v=$__cell', replaceVariables);
       expect(html).toContain('href="http://example.com/x?v=cellText"');
       expect(html).not.toContain('INTERCEPTED');
+    });
+  });
+
+  describe('ReplaceTimeMacros', () => {
+    const tr = {
+      from: dateTime(0),
+      to: dateTime(0),
+      raw: { from: 'now-6h', to: 'now' },
+    } as unknown as TimeRange;
+
+    it('replaces $__from with raw.from', () => {
+      expect(ReplaceTimeMacros(tr, 'http://x/?f=$__from')).toBe('http://x/?f=now-6h');
+    });
+
+    it('replaces $__to with raw.to', () => {
+      expect(ReplaceTimeMacros(tr, 'http://x/?t=$__to')).toBe('http://x/?t=now');
+    });
+
+    it('replaces $__keepTime with from+to pair', () => {
+      expect(ReplaceTimeMacros(tr, 'http://x/?$__keepTime')).toBe(
+        'http://x/?from=now-6h&to=now',
+      );
+    });
+
+    it('passes through content with no time macros unchanged', () => {
+      expect(ReplaceTimeMacros(tr, 'http://x/plain')).toBe('http://x/plain');
+    });
+  });
+
+  describe('ReplaceCellMacros', () => {
+    const rows = [
+      { valueFormatted: 'alpha' } as FormattedColumnValue,
+      { valueFormatted: 'bravo' } as FormattedColumnValue,
+      { valueFormatted: 'charlie' } as FormattedColumnValue,
+    ];
+
+    it('replaces $__cell with the current cell content', () => {
+      expect(ReplaceCellMacros('host-$__cell', 'web-01', rows)).toBe('host-web-01');
+    });
+
+    it('respects word boundary so $__cell does not clobber $__cell_N', () => {
+      // Should replace $__cell (word-boundary) but NOT the $__cell prefix
+      // inside $__cell_1 — the $__cell_N branch handles that separately.
+      const out = ReplaceCellMacros('a=$__cell&b=$__cell_1', 'X', rows);
+      expect(out).toBe('a=X&b=bravo');
+    });
+
+    it('replaces $__cell_N with the Nth row', () => {
+      expect(ReplaceCellMacros('row=$__cell_2', 'current', rows)).toBe('row=charlie');
+    });
+
+    it('skips out-of-bounds $__cell_N references', () => {
+      expect(ReplaceCellMacros('row=$__cell_99', 'current', rows)).toBe('row=$__cell_99');
+    });
+
+    it('returns the input untouched when no macros are present', () => {
+      expect(ReplaceCellMacros('http://x/plain', 'X', rows)).toBe('http://x/plain');
+    });
+  });
+
+  describe('ReplaceCellSplitByPattern', () => {
+    const cellContent = { valueFormatted: 'web-01 prod' } as FormattedColumnValue;
+
+    it('replaces $__pattern_N with the Nth split segment', () => {
+      // Split by whitespace: ['web-01', 'prod']
+      const out = ReplaceCellSplitByPattern(
+        'host=$__pattern_0&env=$__pattern_1',
+        cellContent,
+        '/\\s/',
+      );
+      expect(out).toBe('host=web-01&env=prod');
+    });
+
+    it('returns the input untouched when the cell content is empty', () => {
+      const empty = { valueFormatted: '' } as FormattedColumnValue;
+      expect(ReplaceCellSplitByPattern('host=$__pattern_0', empty, '/\\s/')).toBe(
+        'host=$__pattern_0',
+      );
+    });
+
+    it('returns the input untouched when cellContent is null', () => {
+      expect(
+        ReplaceCellSplitByPattern(
+          'host=$__pattern_0',
+          null as unknown as FormattedColumnValue,
+          '/\\s/',
+        ),
+      ).toBe('host=$__pattern_0');
+    });
+
+    it('leaves $__pattern_N untouched when N exceeds the split count', () => {
+      const out = ReplaceCellSplitByPattern(
+        'a=$__pattern_0&b=$__pattern_9',
+        cellContent,
+        '/\\s/',
+      );
+      expect(out).toBe('a=web-01&b=$__pattern_9');
+    });
+  });
+
+  describe('resolveClickThroughTarget', () => {
+    it('returns _self when neither flag is set', () => {
+      expect(resolveClickThroughTarget(false, false, '')).toBe('_self');
+    });
+
+    it('returns _blank when openNewTab is true', () => {
+      expect(resolveClickThroughTarget(true, false, '')).toBe('_blank');
+    });
+
+    it('returns the custom target when customTargetEnabled is true (wins over openNewTab)', () => {
+      expect(resolveClickThroughTarget(true, true, 'named-window')).toBe('named-window');
+    });
+
+    it('returns the custom target value even when openNewTab is false', () => {
+      expect(resolveClickThroughTarget(false, true, 'x')).toBe('x');
+    });
+  });
+
+  describe('TimeFormatter', () => {
+    const epoch = 1744486055000; // 2025-04-12T19:27:35Z
+
+    it('formats a timestamp in UTC when timeZone is "utc"', () => {
+      const result = TimeFormatter('utc', epoch, 'YYYY-MM-DD HH:mm:ss');
+      expect(result.valueRaw).toBe(epoch);
+      expect(result.valueFormatted).toBe('2025-04-12 19:27:35');
+      expect(result.valueRoundedAndFormatted).toBe(result.valueFormatted);
+      expect(result.valueRounded).toBeNull();
+    });
+
+    it('returns a FormattedColumnValue for a named zone (shape only)', () => {
+      // Non-UTC branch does not actually convert to the named zone — it
+      // passes the already-UTC moment through moment.tz with `format`
+      // + `timezone` args, which produces the UTC time string under a
+      // different label. Pinning that shape is still useful: the function
+      // returns a well-formed FormattedColumnValue rather than throwing.
+      const result = TimeFormatter('America/New_York', epoch, 'YYYY-MM-DD HH:mm:ss');
+      expect(result.valueRaw).toBe(epoch);
+      expect(typeof result.valueFormatted).toBe('string');
+      expect(result.valueFormatted).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+      expect(result.valueRounded).toBeNull();
     });
   });
 });

--- a/src/data/cellRenderer.ts
+++ b/src/data/cellRenderer.ts
@@ -58,22 +58,17 @@ export const TimeFormatter = (timeZone: string, timestamp: number, timestampForm
     }
     return formatted;
   }
-  // this appears to be bugged
-  //
-  // const timestampFormatted = dateTimeForTimeZone(timeZone, timestamp);
-  // console.log(timestampFormatted.toISOString(true));
-
-  // when timezone is browser, convert using Intl package to resolve it
-  // to the actual name moment-tz can use
-  //
-  let formattedWithTimezone = dateTime(timestamp).format(timestampFormat);
-  let useTimezone = timeZone;
-  if (timeZone === 'browser') {
-    useTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  }
-  formattedWithTimezone = moment.tz(
-    dateTime(timestamp).utc().toISOString(true),
-    timestampFormat, useTimezone).format(timestampFormat);
+  // When timezone is 'browser', resolve to the concrete IANA zone name so
+  // moment-timezone can look it up.
+  const useTimezone = timeZone === 'browser'
+    ? Intl.DateTimeFormat().resolvedOptions().timeZone
+    : timeZone;
+  // `moment.tz(ms, tz)` takes a UTC milliseconds timestamp and returns a
+  // Moment expressed in the target zone — the correct conversion overload. The
+  // previous code used `moment.tz(iso, format, tz)`, which is the parsing
+  // overload that treats the string input as already-local-to-tz, so no
+  // UTC→tz conversion happened and non-UTC zones returned UTC digits.
+  const formattedWithTimezone = moment.tz(timestamp, useTimezone).format(timestampFormat);
   const formatted: FormattedColumnValue = {
     valueRaw: timestamp,
     valueFormatted: formattedWithTimezone,

--- a/src/data/columnAliasing.test.ts
+++ b/src/data/columnAliasing.test.ts
@@ -1,0 +1,59 @@
+import { ApplyColumnAliases } from './columnAliasing';
+import { DTColumnType } from './types';
+
+const col = (title: string): DTColumnType =>
+  ({
+    title,
+    data: title,
+    type: 'string',
+    className: '',
+    columnStyles: [],
+    visible: true,
+  } as DTColumnType);
+
+describe('ApplyColumnAliases', () => {
+  it('leaves column titles unchanged when no aliases are configured', () => {
+    const cols = [col('time'), col('A-series')];
+    const result = ApplyColumnAliases(cols, []);
+    expect(result.map((c) => c.title)).toEqual(['time', 'A-series']);
+  });
+
+  it('renames a matching column title to its alias', () => {
+    const cols = [col('A-series'), col('B-series')];
+    ApplyColumnAliases(cols, [{ name: 'A-series', alias: 'Alpha' }]);
+    expect(cols.map((c) => c.title)).toEqual(['Alpha', 'B-series']);
+  });
+
+  it('leaves untouched columns unchanged when only some match', () => {
+    const cols = [col('A'), col('B'), col('C')];
+    ApplyColumnAliases(cols, [{ name: 'B', alias: 'Bravo' }]);
+    expect(cols.map((c) => c.title)).toEqual(['A', 'Bravo', 'C']);
+  });
+
+  it('uses the first alias when the same name appears twice', () => {
+    const cols = [col('host')];
+    ApplyColumnAliases(cols, [
+      { name: 'host', alias: 'Host1' },
+      { name: 'host', alias: 'Host2' },
+    ]);
+    expect(cols[0].title).toBe('Host1');
+  });
+
+  it('mutates the input array in place and returns the same reference', () => {
+    const cols = [col('x')];
+    const result = ApplyColumnAliases(cols, [{ name: 'x', alias: 'X!' }]);
+    expect(result).toBe(cols);
+    expect(cols[0].title).toBe('X!');
+  });
+
+  it('tolerates an empty columns array', () => {
+    expect(ApplyColumnAliases([], [{ name: 'a', alias: 'A' }])).toEqual([]);
+  });
+
+  it('skips aliases with empty string values (falls back to original title)', () => {
+    // `if (anAlias)` rejects '' — original title preserved.
+    const cols = [col('time')];
+    ApplyColumnAliases(cols, [{ name: 'time', alias: '' }]);
+    expect(cols[0].title).toBe('time');
+  });
+});

--- a/src/data/columnStyles.test.ts
+++ b/src/data/columnStyles.test.ts
@@ -54,4 +54,58 @@ describe('Column Styles', () => {
       expect(columns[0].columnStyles[0]).toEqual(columnStyles[0]);
     });
   });
+
+  describe('regex match path', () => {
+    const makeCols = (titles: string[]): DTColumnType[] =>
+      titles.map((title) => ({
+        title,
+        data: title,
+        type: 'string',
+        className: '',
+        columnStyles: [],
+        visible: true,
+      } as DTColumnType));
+
+    const makeStyle = (nameOrRegex: string): ColumnStyleItemType =>
+      ({
+        ...columnStyles[0],
+        nameOrRegex,
+      } as ColumnStyleItemType);
+
+    it('matches columns whose title matches the regex between slashes', () => {
+      const cols = makeCols(['web-01', 'db-02', 'web-09']);
+      const style = makeStyle('/^web-/');
+      ApplyColumnStyles(cols, [style]);
+      expect(cols[0].columnStyles).toHaveLength(1);
+      expect(cols[1].columnStyles).toHaveLength(0);
+      expect(cols[2].columnStyles).toHaveLength(1);
+    });
+
+    it('does not match when the regex has no hit', () => {
+      const cols = makeCols(['A', 'B']);
+      const style = makeStyle('/^X/');
+      ApplyColumnStyles(cols, [style]);
+      expect(cols[0].columnStyles).toHaveLength(0);
+      expect(cols[1].columnStyles).toHaveLength(0);
+    });
+
+    it('stops at the first style match per column (break after push)', () => {
+      const cols = makeCols(['web-01']);
+      const first = makeStyle('/^web-/');
+      const second = { ...makeStyle('/^web-/'), label: 'Second' } as ColumnStyleItemType;
+      ApplyColumnStyles(cols, [first, second]);
+      expect(cols[0].columnStyles).toHaveLength(1);
+      expect(cols[0].columnStyles[0]).toBe(first);
+    });
+
+    it('treats unslashed nameOrRegex as exact string match, not regex', () => {
+      // 'web' would regex-match 'web-01' — but without slashes it's an
+      // exact string equality check, so 'web-01' does NOT match 'web'.
+      const cols = makeCols(['web', 'web-01']);
+      const style = makeStyle('web');
+      ApplyColumnStyles(cols, [style]);
+      expect(cols[0].columnStyles).toHaveLength(1);
+      expect(cols[1].columnStyles).toHaveLength(0);
+    });
+  });
 });

--- a/src/data/columnWidthHints.test.ts
+++ b/src/data/columnWidthHints.test.ts
@@ -1,0 +1,62 @@
+import { ApplyColumnWidthHints } from './columnWidthHints';
+import { DTColumnType } from './types';
+
+const col = (title: string): DTColumnType =>
+  ({
+    title,
+    data: title,
+    type: 'string',
+    className: '',
+    columnStyles: [],
+    visible: true,
+  } as DTColumnType);
+
+describe('ApplyColumnWidthHints', () => {
+  it('leaves widthHint unset when no hints are configured', () => {
+    const cols = [col('time'), col('A')];
+    ApplyColumnWidthHints(cols, []);
+    expect(cols.map((c) => c.widthHint)).toEqual([undefined, undefined]);
+  });
+
+  it('stamps the configured width on a matching column', () => {
+    const cols = [col('time')];
+    ApplyColumnWidthHints(cols, [{ name: 'time', width: '180px' }]);
+    expect(cols[0].widthHint).toBe('180px');
+  });
+
+  it('applies hints only to matching columns', () => {
+    const cols = [col('A'), col('B'), col('C')];
+    ApplyColumnWidthHints(cols, [
+      { name: 'A', width: '100px' },
+      { name: 'C', width: '300px' },
+    ]);
+    expect(cols.map((c) => c.widthHint)).toEqual(['100px', undefined, '300px']);
+  });
+
+  it('returns the first matching hint when the same name appears twice', () => {
+    const cols = [col('value')];
+    ApplyColumnWidthHints(cols, [
+      { name: 'value', width: '120px' },
+      { name: 'value', width: '240px' },
+    ]);
+    expect(cols[0].widthHint).toBe('120px');
+  });
+
+  it('mutates the input array in place and returns the same reference', () => {
+    const cols = [col('x')];
+    const result = ApplyColumnWidthHints(cols, [{ name: 'x', width: '50px' }]);
+    expect(result).toBe(cols);
+    expect(cols[0].widthHint).toBe('50px');
+  });
+
+  it('tolerates an empty columns array', () => {
+    expect(ApplyColumnWidthHints([], [{ name: 'a', width: '1px' }])).toEqual([]);
+  });
+
+  it('skips hints with empty width strings (no mutation)', () => {
+    // `if (aHint)` rejects '' — widthHint stays untouched.
+    const cols = [col('time')];
+    ApplyColumnWidthHints(cols, [{ name: 'time', width: '' }]);
+    expect(cols[0].widthHint).toBeUndefined();
+  });
+});

--- a/src/data/createdCellHelpers.ts
+++ b/src/data/createdCellHelpers.ts
@@ -31,7 +31,6 @@ export const processRowStyle = (
     }
     rowColorData = getCellColors(
       aColumnStyle,
-      columnNumber,
       rowData[columnNumber + rowNumberOffset]
     );
     if (!rowColorData) {
@@ -81,7 +80,6 @@ export const processRowColumnStyle = (
         }
         rowColorData = getCellColors(
           aColumnStyle,
-          columnNumber,
           rowData[columnNumber + rowNumberOffset]
         );
       }

--- a/src/data/dataHelpers.test.ts
+++ b/src/data/dataHelpers.test.ts
@@ -1,7 +1,21 @@
-import { getCellColors, GetColorForValue, GetColorIndexForValue, getColumnClassName } from './dataHelpers';
+import {
+  ConvertDataFrameToDataTableFormat,
+  getCellColors,
+  GetColorForValue,
+  GetColorIndexForValue,
+  getColumnClassName,
+} from './dataHelpers';
 import { ColumnStyleColoring } from 'types';
 import { ColumnStyles, ColumnStyleItemType } from 'components/options/columnstyles/types';
 import { FormattedColumnValue } from './types';
+import {
+  createTheme,
+  dateTime,
+  FieldConfigSource,
+  FieldType,
+  TimeRange,
+  toDataFrame,
+} from '@grafana/data';
 
 const metricStyle = (
   colorMode: ColumnStyleColoring | undefined,
@@ -155,5 +169,111 @@ describe('getCellColors', () => {
   it('returns null when cellData is null', () => {
     const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
     expect(getCellColors(style, 0, null as unknown as FormattedColumnValue)).toBeNull();
+  });
+});
+
+describe('ConvertDataFrameToDataTableFormat', () => {
+  const theme = createTheme();
+  const noopReplaceVariables = (s: string) => s;
+  const emptyFieldConfig = { defaults: {}, overrides: [] } as unknown as FieldConfigSource;
+  const fakeTimeRange = {
+    from: dateTime(0),
+    to: dateTime(0),
+    raw: { from: 'now-1h', to: 'now' },
+  } as unknown as TimeRange;
+  const alignment = { numbers: true, strings: false };
+
+  const twoFieldFrame = () =>
+    toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000, 3000] },
+        { name: 'value', type: FieldType.number, values: [10, 20, 30] },
+      ],
+    });
+
+  it('maps each field to a DTColumnType with the class derived from alignment', () => {
+    const { columns } = ConvertDataFrameToDataTableFormat(
+      [twoFieldFrame()],
+      emptyFieldConfig,
+      'utc',
+      fakeTimeRange,
+      alignment,
+      false,
+      [],
+      theme,
+      noopReplaceVariables,
+    );
+    expect(columns.map((c) => c.title)).toEqual(['time', 'value']);
+    expect(columns.map((c) => c.type)).toEqual(['time', 'number']);
+    // Numbers aligned right because alignment.numbers=true; time is coerced to number for class purposes.
+    expect(columns.every((c) => c.className === 'dt-right')).toBe(true);
+    expect(columns.every((c) => c.visible === true)).toBe(true);
+  });
+
+  it('emits one row object per frame row, keyed by normalized field names', () => {
+    const { rows } = ConvertDataFrameToDataTableFormat(
+      [twoFieldFrame()],
+      emptyFieldConfig,
+      'utc',
+      fakeTimeRange,
+      alignment,
+      false,
+      [],
+      theme,
+      noopReplaceVariables,
+    );
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toEqual(expect.objectContaining({ time: 1000, value: 10 }));
+    expect(rows[2]).toEqual(expect.objectContaining({ time: 3000, value: 30 }));
+  });
+
+  it('prepends a rowNumber column and stamps row indices when rowNumbersEnabled', () => {
+    const { columns, rows } = ConvertDataFrameToDataTableFormat(
+      [twoFieldFrame()],
+      emptyFieldConfig,
+      'utc',
+      fakeTimeRange,
+      alignment,
+      true,
+      [],
+      theme,
+      noopReplaceVariables,
+    );
+    expect(columns[0]).toEqual(
+      expect.objectContaining({ title: 'row', data: 'rowNumber', widthHint: '1%' }),
+    );
+    expect(columns).toHaveLength(3); // rowNumber + 2 data fields
+    expect(rows.map((r) => r.rowNumber)).toEqual([1, 2, 3]);
+  });
+
+  it('hides a column when its matched style is HIDDEN (only via rowNumbers branch)', () => {
+    // The visibility toggle lives in the `if (rowNumbersEnabled)` block —
+    // matches the current implementation even though the location is
+    // arguably a bug. Pin observed behaviour rather than pretend.
+    const hiddenStyle = {
+      activeStyle: ColumnStyles.HIDDEN,
+      enabled: true,
+      label: 'hide-value',
+      nameOrRegex: 'value',
+      order: 0,
+      dateStyle: {},
+      hiddenStyle: {},
+      metricStyle: {},
+      stringStyle: {},
+    } as unknown as ColumnStyleItemType;
+
+    const { columns } = ConvertDataFrameToDataTableFormat(
+      [twoFieldFrame()],
+      emptyFieldConfig,
+      'utc',
+      fakeTimeRange,
+      alignment,
+      true,
+      [hiddenStyle],
+      theme,
+      noopReplaceVariables,
+    );
+    const valueCol = columns.find((c) => c.title === 'value');
+    expect(valueCol?.visible).toBe(false);
   });
 });

--- a/src/data/dataHelpers.test.ts
+++ b/src/data/dataHelpers.test.ts
@@ -1,4 +1,33 @@
-import { getColumnClassName } from './dataHelpers';
+import { getCellColors, GetColorForValue, GetColorIndexForValue, getColumnClassName } from './dataHelpers';
+import { ColumnStyleColoring } from 'types';
+import { ColumnStyles, ColumnStyleItemType } from 'components/options/columnstyles/types';
+import { FormattedColumnValue } from './types';
+
+const metricStyle = (
+  colorMode: ColumnStyleColoring | undefined,
+  thresholds: Array<{ value: number; color: string; state: number }>,
+): ColumnStyleItemType =>
+  ({
+    activeStyle: ColumnStyles.METRIC,
+    metricStyle: {
+      colorMode,
+      thresholds,
+      colors: [],
+      decimals: '2',
+      scaledDecimals: null,
+      unitFormat: 'short',
+      ignoreNullValues: true,
+      alias: '',
+    },
+  } as unknown as ColumnStyleItemType);
+
+const cell = (raw: number | string | null): FormattedColumnValue =>
+  ({
+    valueRaw: raw,
+    valueFormatted: String(raw),
+    valueRounded: null,
+    valueRoundedAndFormatted: null,
+  } as FormattedColumnValue);
 
 // getColumnClassName is the gate that turns the panel-level alignment toggles
 // into a DataTables class on each column. The per-column override runs later
@@ -26,5 +55,105 @@ describe('getColumnClassName', () => {
     ['boolean', both, ''],
   ])('%s column with alignment=%j → %s', (columnType, alignment, expected) => {
     expect(getColumnClassName(alignment, columnType)).toBe(expected);
+  });
+});
+
+describe('GetColorForValue', () => {
+  const thresholds = [
+    { value: 0, color: 'green', state: 0 },
+    { value: 10, color: 'yellow', state: 1 },
+    { value: 20, color: 'red', state: 2 },
+  ];
+  const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
+
+  it.each([
+    [-5, 'green'],
+    [0, 'green'],
+    [5, 'green'],
+    [10, 'yellow'],
+    [15, 'yellow'],
+    [20, 'red'],
+    [999, 'red'],
+  ])('value=%i → color=%s', (value, expected) => {
+    expect(GetColorForValue(value, style)).toBe(expected);
+  });
+
+  it('returns null when no thresholds are defined', () => {
+    const empty = metricStyle(ColumnStyleColoring.Cell, undefined as unknown as typeof thresholds);
+    expect(GetColorForValue(5, empty)).toBeNull();
+  });
+});
+
+describe('GetColorIndexForValue', () => {
+  const thresholds = [
+    { value: 0, color: 'green', state: 0 },
+    { value: 10, color: 'yellow', state: 1 },
+    { value: 20, color: 'red', state: 2 },
+  ];
+  const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
+
+  it.each([
+    [-5, 0],
+    [5, 0],
+    [10, 1],
+    [15, 1],
+    [20, 2],
+    [100, 2],
+  ])('value=%i → index=%i', (value, expected) => {
+    expect(GetColorIndexForValue(value, style)).toBe(expected);
+  });
+});
+
+describe('getCellColors', () => {
+  const thresholds = [
+    { value: 0, color: 'green', state: 0 },
+    { value: 50, color: 'red', state: 1 },
+  ];
+
+  it('returns null for a null column style', () => {
+    expect(getCellColors(null, 0, cell(42))).toBeNull();
+  });
+
+  it('returns null for a non-metric column', () => {
+    const stringStyle = { ...metricStyle(ColumnStyleColoring.Cell, thresholds), activeStyle: ColumnStyles.STRING };
+    expect(getCellColors(stringStyle, 0, cell(42))).toBeNull();
+  });
+
+  it('returns bgColor + white text when colorMode=Cell and value in high band', () => {
+    const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
+    const result = getCellColors(style, 0, cell(75));
+    expect(result).toEqual({ bgColor: 'red', bgColorIndex: 1, color: 'white', colorIndex: null });
+  });
+
+  it('returns color on text (no bg) when colorMode=Value', () => {
+    const style = metricStyle(ColumnStyleColoring.Value, thresholds);
+    const result = getCellColors(style, 0, cell(75));
+    expect(result).toEqual({ bgColor: null, bgColorIndex: null, color: 'red', colorIndex: 1 });
+  });
+
+  it('leaves colors unset when colorMode=Disabled', () => {
+    // Disabled is not one of Cell/Row/RowColumn/Value — the outer `if` only
+    // enters when thresholds exist, but neither inner branch matches, so
+    // every color field stays null.
+    const style = metricStyle(ColumnStyleColoring.Disabled, thresholds);
+    expect(getCellColors(style, 0, cell(75))).toEqual({
+      bgColor: null,
+      bgColorIndex: null,
+      color: null,
+      colorIndex: null,
+    });
+  });
+
+  it('skips coloring when valueRaw is null', () => {
+    const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
+    const result = getCellColors(style, 0, cell(null));
+    // bg/color stay null, but color is still set to 'white' because the
+    // colorMode triggered the Cell branch regardless of value validity.
+    expect(result).toEqual({ bgColor: null, bgColorIndex: null, color: 'white', colorIndex: null });
+  });
+
+  it('returns null when cellData is null', () => {
+    const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
+    expect(getCellColors(style, 0, null as unknown as FormattedColumnValue)).toBeNull();
   });
 });

--- a/src/data/dataHelpers.test.ts
+++ b/src/data/dataHelpers.test.ts
@@ -10,10 +10,8 @@ import { ColumnStyles, ColumnStyleItemType } from 'components/options/columnstyl
 import { FormattedColumnValue } from './types';
 import {
   createTheme,
-  dateTime,
   FieldConfigSource,
   FieldType,
-  TimeRange,
   toDataFrame,
 } from '@grafana/data';
 
@@ -125,23 +123,23 @@ describe('getCellColors', () => {
   ];
 
   it('returns null for a null column style', () => {
-    expect(getCellColors(null, 0, cell(42))).toBeNull();
+    expect(getCellColors(null, cell(42))).toBeNull();
   });
 
   it('returns null for a non-metric column', () => {
     const stringStyle = { ...metricStyle(ColumnStyleColoring.Cell, thresholds), activeStyle: ColumnStyles.STRING };
-    expect(getCellColors(stringStyle, 0, cell(42))).toBeNull();
+    expect(getCellColors(stringStyle, cell(42))).toBeNull();
   });
 
   it('returns bgColor + white text when colorMode=Cell and value in high band', () => {
     const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
-    const result = getCellColors(style, 0, cell(75));
+    const result = getCellColors(style, cell(75));
     expect(result).toEqual({ bgColor: 'red', bgColorIndex: 1, color: 'white', colorIndex: null });
   });
 
   it('returns color on text (no bg) when colorMode=Value', () => {
     const style = metricStyle(ColumnStyleColoring.Value, thresholds);
-    const result = getCellColors(style, 0, cell(75));
+    const result = getCellColors(style, cell(75));
     expect(result).toEqual({ bgColor: null, bgColorIndex: null, color: 'red', colorIndex: 1 });
   });
 
@@ -150,7 +148,7 @@ describe('getCellColors', () => {
     // enters when thresholds exist, but neither inner branch matches, so
     // every color field stays null.
     const style = metricStyle(ColumnStyleColoring.Disabled, thresholds);
-    expect(getCellColors(style, 0, cell(75))).toEqual({
+    expect(getCellColors(style, cell(75))).toEqual({
       bgColor: null,
       bgColorIndex: null,
       color: null,
@@ -160,7 +158,7 @@ describe('getCellColors', () => {
 
   it('skips coloring when valueRaw is null', () => {
     const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
-    const result = getCellColors(style, 0, cell(null));
+    const result = getCellColors(style, cell(null));
     // bg/color stay null, but color is still set to 'white' because the
     // colorMode triggered the Cell branch regardless of value validity.
     expect(result).toEqual({ bgColor: null, bgColorIndex: null, color: 'white', colorIndex: null });
@@ -168,7 +166,7 @@ describe('getCellColors', () => {
 
   it('returns null when cellData is null', () => {
     const style = metricStyle(ColumnStyleColoring.Cell, thresholds);
-    expect(getCellColors(style, 0, null as unknown as FormattedColumnValue)).toBeNull();
+    expect(getCellColors(style, null as unknown as FormattedColumnValue)).toBeNull();
   });
 });
 
@@ -176,11 +174,6 @@ describe('ConvertDataFrameToDataTableFormat', () => {
   const theme = createTheme();
   const noopReplaceVariables = (s: string) => s;
   const emptyFieldConfig = { defaults: {}, overrides: [] } as unknown as FieldConfigSource;
-  const fakeTimeRange = {
-    from: dateTime(0),
-    to: dateTime(0),
-    raw: { from: 'now-1h', to: 'now' },
-  } as unknown as TimeRange;
   const alignment = { numbers: true, strings: false };
 
   const twoFieldFrame = () =>
@@ -191,18 +184,21 @@ describe('ConvertDataFrameToDataTableFormat', () => {
       ],
     });
 
+  const baseOpts = {
+    fieldConfig: emptyFieldConfig,
+    userTimeZone: 'utc',
+    alignment,
+    theme,
+    replaceVariables: noopReplaceVariables,
+  };
+
   it('maps each field to a DTColumnType with the class derived from alignment', () => {
-    const { columns } = ConvertDataFrameToDataTableFormat(
-      [twoFieldFrame()],
-      emptyFieldConfig,
-      'utc',
-      fakeTimeRange,
-      alignment,
-      false,
-      [],
-      theme,
-      noopReplaceVariables,
-    );
+    const { columns } = ConvertDataFrameToDataTableFormat({
+      ...baseOpts,
+      dataFrames: [twoFieldFrame()],
+      rowNumbersEnabled: false,
+      columnStyles: [],
+    });
     expect(columns.map((c) => c.title)).toEqual(['time', 'value']);
     expect(columns.map((c) => c.type)).toEqual(['time', 'number']);
     // Numbers aligned right because alignment.numbers=true; time is coerced to number for class purposes.
@@ -211,34 +207,24 @@ describe('ConvertDataFrameToDataTableFormat', () => {
   });
 
   it('emits one row object per frame row, keyed by normalized field names', () => {
-    const { rows } = ConvertDataFrameToDataTableFormat(
-      [twoFieldFrame()],
-      emptyFieldConfig,
-      'utc',
-      fakeTimeRange,
-      alignment,
-      false,
-      [],
-      theme,
-      noopReplaceVariables,
-    );
+    const { rows } = ConvertDataFrameToDataTableFormat({
+      ...baseOpts,
+      dataFrames: [twoFieldFrame()],
+      rowNumbersEnabled: false,
+      columnStyles: [],
+    });
     expect(rows).toHaveLength(3);
     expect(rows[0]).toEqual(expect.objectContaining({ time: 1000, value: 10 }));
     expect(rows[2]).toEqual(expect.objectContaining({ time: 3000, value: 30 }));
   });
 
   it('prepends a rowNumber column and stamps row indices when rowNumbersEnabled', () => {
-    const { columns, rows } = ConvertDataFrameToDataTableFormat(
-      [twoFieldFrame()],
-      emptyFieldConfig,
-      'utc',
-      fakeTimeRange,
-      alignment,
-      true,
-      [],
-      theme,
-      noopReplaceVariables,
-    );
+    const { columns, rows } = ConvertDataFrameToDataTableFormat({
+      ...baseOpts,
+      dataFrames: [twoFieldFrame()],
+      rowNumbersEnabled: true,
+      columnStyles: [],
+    });
     expect(columns[0]).toEqual(
       expect.objectContaining({ title: 'row', data: 'rowNumber', widthHint: '1%' }),
     );
@@ -262,17 +248,12 @@ describe('ConvertDataFrameToDataTableFormat', () => {
       stringStyle: {},
     } as unknown as ColumnStyleItemType;
 
-    const { columns } = ConvertDataFrameToDataTableFormat(
-      [twoFieldFrame()],
-      emptyFieldConfig,
-      'utc',
-      fakeTimeRange,
-      alignment,
-      true,
-      [hiddenStyle],
-      theme,
-      noopReplaceVariables,
-    );
+    const { columns } = ConvertDataFrameToDataTableFormat({
+      ...baseOpts,
+      dataFrames: [twoFieldFrame()],
+      rowNumbersEnabled: true,
+      columnStyles: [hiddenStyle],
+    });
     const valueCol = columns.find((c) => c.title === 'value');
     expect(valueCol?.visible).toBe(false);
   });

--- a/src/data/dataHelpers.test.ts
+++ b/src/data/dataHelpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  BuildColumnDefs,
   ConvertDataFrameToDataTableFormat,
   getCellColors,
   GetColorForValue,
@@ -7,11 +8,13 @@ import {
 } from './dataHelpers';
 import { ColumnStyleColoring } from 'types';
 import { ColumnStyles, ColumnStyleItemType } from 'components/options/columnstyles/types';
-import { FormattedColumnValue } from './types';
+import { DTColumnType, FormattedColumnValue } from './types';
 import {
   createTheme,
+  dateTime,
   FieldConfigSource,
   FieldType,
+  TimeRange,
   toDataFrame,
 } from '@grafana/data';
 
@@ -256,5 +259,61 @@ describe('ConvertDataFrameToDataTableFormat', () => {
     });
     const valueCol = columns.find((c) => c.title === 'value');
     expect(valueCol?.visible).toBe(false);
+  });
+});
+
+describe('BuildColumnDefs', () => {
+  // Minimal DTData fixture — two columns, one data row.
+  const dtData = {
+    Columns: [
+      {
+        title: 'name',
+        data: 'name',
+        type: 'string',
+        className: '',
+        columnStyles: [],
+        widthHint: '',
+        visible: true,
+      } as DTColumnType,
+      {
+        title: 'value',
+        data: 'value',
+        type: 'number',
+        className: '',
+        columnStyles: [],
+        widthHint: '',
+        visible: true,
+      } as DTColumnType,
+    ],
+    Rows: [{ name: 'A', value: 1 }],
+  };
+
+  // Pins the options-object API so a future refactor can't silently revert to
+  // positional args. Also asserts the sentinel `{ targets: '_all' }` entry
+  // that BuildColumnDefs appends — DataTables relies on it to suppress a
+  // "unknown column" dialog when toggling the row-number column at runtime.
+  it('accepts a BuildColumnDefsOptions object and emits one def per column plus the _all sentinel', () => {
+    const defs = BuildColumnDefs({
+      rowNumbersEnabled: false,
+      fontSizePercent: '100%',
+      alignment: { numbers: true, strings: false },
+      timeRange: {
+        from: dateTime(0),
+        to: dateTime(0),
+        raw: { from: 'now-1h', to: 'now' },
+      } as unknown as TimeRange,
+      replaceVariables: (s: string) => s,
+      dtData,
+    });
+
+    // 2 column defs + 1 sentinel
+    expect(defs).toHaveLength(3);
+    const realDefs = defs.filter((d) => (d as unknown as Record<string, unknown>).targets !== '_all');
+    expect(realDefs).toHaveLength(2);
+    expect(realDefs.map((d) => (d as unknown as Record<string, unknown>).targets)).toEqual([0, 1]);
+
+    const sentinel = defs.find((d) => (d as unknown as Record<string, unknown>).targets === '_all');
+    expect(sentinel).toBeDefined();
+    expect((sentinel as unknown as Record<string, unknown>).defaultContent).toBe('-');
   });
 });

--- a/src/data/dataHelpers.test.ts
+++ b/src/data/dataHelpers.test.ts
@@ -288,6 +288,11 @@ describe('BuildColumnDefs', () => {
     Rows: [{ name: 'A', value: 1 }],
   };
 
+  // `ConfigColumnDefs` from datatables.net is a narrow union that doesn't
+  // expose an index signature, so probing runtime properties needs a cast.
+  // Factor it once so the assertions below stay readable.
+  const asRecord = (d: unknown) => d as Record<string, unknown>;
+
   // Pins the options-object API so a future refactor can't silently revert to
   // positional args. Also asserts the sentinel `{ targets: '_all' }` entry
   // that BuildColumnDefs appends — DataTables relies on it to suppress a
@@ -308,12 +313,12 @@ describe('BuildColumnDefs', () => {
 
     // 2 column defs + 1 sentinel
     expect(defs).toHaveLength(3);
-    const realDefs = defs.filter((d) => (d as unknown as Record<string, unknown>).targets !== '_all');
+    const realDefs = defs.filter((d) => asRecord(d).targets !== '_all');
     expect(realDefs).toHaveLength(2);
-    expect(realDefs.map((d) => (d as unknown as Record<string, unknown>).targets)).toEqual([0, 1]);
+    expect(realDefs.map((d) => asRecord(d).targets)).toEqual([0, 1]);
 
-    const sentinel = defs.find((d) => (d as unknown as Record<string, unknown>).targets === '_all');
+    const sentinel = defs.find((d) => asRecord(d).targets === '_all');
     expect(sentinel).toBeDefined();
-    expect((sentinel as unknown as Record<string, unknown>).defaultContent).toBe('-');
+    expect(asRecord(sentinel).defaultContent).toBe('-');
   });
 });

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -152,13 +152,24 @@ export const ConvertDataFrameToDataTableFormat = (
   return { columns, rows };
 }
 
-export const BuildColumnDefs = (
-  rowNumbersEnabled: boolean,
-  fontSizePercent: string,
-  alignment: AlignmentFlags,
-  timeRange: TimeRange,
-  replaceVariables: InterpolateFunction,
-  dtData: DTData): ConfigColumnDefs[] => {
+export type BuildColumnDefsOptions = {
+  rowNumbersEnabled: boolean;
+  fontSizePercent: string;
+  alignment: AlignmentFlags;
+  timeRange: TimeRange;
+  replaceVariables: InterpolateFunction;
+  dtData: DTData;
+};
+
+export const BuildColumnDefs = (opts: BuildColumnDefsOptions): ConfigColumnDefs[] => {
+  const {
+    rowNumbersEnabled,
+    fontSizePercent,
+    alignment,
+    timeRange,
+    replaceVariables,
+    dtData,
+  } = opts;
 
   const columnDefs: ConfigColumnDefs[] = [];
   let rowNumberOffset = 0;

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -68,9 +68,10 @@ export const ConvertDataFrameToDataTableFormat = (
   alignment: AlignmentFlags,
   rowNumbersEnabled: boolean,
   columnStyles: ColumnStyleItemType[],
-  theme: GrafanaTheme2): { columns: DTColumnType[]; rows: any[] } => {
+  theme: GrafanaTheme2,
+  replaceVariables: InterpolateFunction): { columns: DTColumnType[]; rows: any[] } => {
   DataFrameToDisplay(dataFrames);
-  dataFrames = ApplyGrafanaOverrides(dataFrames, theme);
+  dataFrames = ApplyGrafanaOverrides(dataFrames, theme, replaceVariables);
   const dataFrame = dataFrames[0];
   let columns: DTColumnType[] = dataFrame.fields.map((field) => {
     const columnClassName = getColumnClassName(alignment, field.type as string)

--- a/src/data/dataHelpers.ts
+++ b/src/data/dataHelpers.ts
@@ -60,18 +60,23 @@ export type AlignmentFlags = {
   strings: boolean;
 };
 
+export type ConvertDataFrameOptions = {
+  dataFrames: DataFrame[];
+  fieldConfig: FieldConfigSource<any>;
+  userTimeZone: string;
+  alignment: AlignmentFlags;
+  rowNumbersEnabled: boolean;
+  columnStyles: ColumnStyleItemType[];
+  theme: GrafanaTheme2;
+  replaceVariables: InterpolateFunction;
+};
+
 export const ConvertDataFrameToDataTableFormat = (
-  dataFrames: DataFrame[],
-  fieldConfig: FieldConfigSource<any>,
-  userTimeZone: string,
-  timeRange: TimeRange,
-  alignment: AlignmentFlags,
-  rowNumbersEnabled: boolean,
-  columnStyles: ColumnStyleItemType[],
-  theme: GrafanaTheme2,
-  replaceVariables: InterpolateFunction): { columns: DTColumnType[]; rows: any[] } => {
-  DataFrameToDisplay(dataFrames);
-  dataFrames = ApplyGrafanaOverrides(dataFrames, theme, replaceVariables);
+  opts: ConvertDataFrameOptions,
+): { columns: DTColumnType[]; rows: any[] } => {
+  const { fieldConfig, userTimeZone, alignment, rowNumbersEnabled, columnStyles, theme, replaceVariables } = opts;
+  DataFrameToDisplay(opts.dataFrames);
+  const dataFrames = ApplyGrafanaOverrides(opts.dataFrames, theme, replaceVariables);
   const dataFrame = dataFrames[0];
   let columns: DTColumnType[] = dataFrame.fields.map((field) => {
     const columnClassName = getColumnClassName(alignment, field.type as string)
@@ -148,8 +153,6 @@ export const ConvertDataFrameToDataTableFormat = (
 }
 
 export const BuildColumnDefs = (
-  emptyDataEnabled: boolean,
-  emptyDataText: string,
   rowNumbersEnabled: boolean,
   fontSizePercent: string,
   alignment: AlignmentFlags,
@@ -184,8 +187,7 @@ export const BuildColumnDefs = (
       width: dtData.Columns[i].widthHint,
       targets: i + rowNumberOffset,
       defaultContent: dtData.Columns,
-      //defaultContent: emptyDataEnabled ? emptyDataText : '',
-      data: function (row: any, type: any, set: any, meta: any) {
+      data: function (row: any, type: any, _set: any, meta: any) {
         if (type === undefined) {
           return null;
         }
@@ -195,7 +197,7 @@ export const BuildColumnDefs = (
         }
         return null;
       },
-      render: function (data: any, type: any, val: any[], meta: CellMetaSettings) {
+      render: function (_data: any, type: any, val: any[], meta: CellMetaSettings) {
         if (type === undefined) {
           return null;
         }
@@ -248,11 +250,6 @@ export const BuildColumnDefs = (
         // hidden columns have null data
         if (cellContent === null || rowData === null) {
           return;
-        }
-        // undefined types should have numerical data, any others are already formatted
-        let actualColumn = colIndex;
-        if (rowNumbersEnabled) {
-          actualColumn -= 1;
         }
         // instead of using cellContent, use the formatted data from dtData.Rows
         const aRow = dtData.Rows[rowIndex];
@@ -307,7 +304,7 @@ export const BuildColumnDefs = (
           //    set the cell colors individually
           //
           let colorData: any;
-          colorData = getCellColors(aStyle, actualColumn, cellValueFormatted);
+          colorData = getCellColors(aStyle, cellValueFormatted);
           if (!colorData) {
             return;
           }
@@ -382,7 +379,7 @@ export const getColumnClassName = (alignment: AlignmentFlags, columnType: string
   return columnClassName;
 }
 
-export const getCellColors = (aColumnStyle: ColumnStyleItemType | null, columnNumber: any, cellData: FormattedColumnValue) => {
+export const getCellColors = (aColumnStyle: ColumnStyleItemType | null, cellData: FormattedColumnValue) => {
   if (aColumnStyle === null || cellData === null || cellData === undefined) {
     return null;
   }

--- a/src/data/mappingProcessor.test.ts
+++ b/src/data/mappingProcessor.test.ts
@@ -1,0 +1,71 @@
+import { MappingType, ValueMapping } from '@grafana/data';
+import { FormattedColumnValue } from './types';
+import { ApplyMappings, GetMappings } from './mappingProcessor';
+
+const valueMapping = (key: string, text: string): ValueMapping =>
+  ({ type: MappingType.ValueToText, options: { [key]: { text } } } as ValueMapping);
+
+const makeValue = (partial: Partial<FormattedColumnValue>): FormattedColumnValue =>
+  ({
+    valueRaw: 0,
+    valueFormatted: '',
+    valueRounded: 0,
+    valueRoundedAndFormatted: 0,
+    ...partial,
+  } as FormattedColumnValue);
+
+describe('GetMappings', () => {
+  const fieldConfigMappings: ValueMapping[] = [valueMapping('a', 'alpha')];
+  const dataMappings: ValueMapping[] = [valueMapping('b', 'bravo')];
+
+  it('prefers fieldConfig mappings when they exist', () => {
+    expect(GetMappings(fieldConfigMappings, dataMappings)).toBe(fieldConfigMappings);
+  });
+
+  it('falls back to data mappings when fieldConfig is empty', () => {
+    expect(GetMappings([], dataMappings)).toBe(dataMappings);
+  });
+
+  it('falls back to data mappings when fieldConfig is undefined', () => {
+    expect(GetMappings(undefined, dataMappings)).toBe(dataMappings);
+  });
+
+  it('returns undefined when neither source has mappings', () => {
+    expect(GetMappings(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('ApplyMappings', () => {
+  const mappings: ValueMapping[] = [valueMapping('online', 'UP')];
+
+  it('returns null when the value is null or undefined', () => {
+    expect(ApplyMappings(null as unknown as FormattedColumnValue, mappings)).toBeNull();
+    expect(ApplyMappings(undefined as unknown as FormattedColumnValue, mappings)).toBeNull();
+  });
+
+  it('returns null when the value has no valueRaw', () => {
+    expect(ApplyMappings(makeValue({ valueRaw: 0 }), mappings)).toBeNull();
+  });
+
+  it('returns null when no mapping matches the valueRaw', () => {
+    expect(ApplyMappings(makeValue({ valueRaw: 'unknown' }), mappings)).toBeNull();
+  });
+
+  it('overwrites valueFormatted with the mapped text and returns the value', () => {
+    const input = makeValue({ valueRaw: 'online', valueFormatted: 'raw-string' });
+    const result = ApplyMappings(input, mappings);
+    expect(result).not.toBeNull();
+    expect(result?.valueFormatted).toBe('UP');
+    // Returns the same object reference (mutates in place)
+    expect(result).toBe(input);
+  });
+
+  it('defaults to an empty valueFormatted when the mapping result has no text', () => {
+    const noTextMapping: ValueMapping[] = [
+      { type: MappingType.ValueToText, options: { online: {} } } as ValueMapping,
+    ];
+    const input = makeValue({ valueRaw: 'online', valueFormatted: 'raw-string' });
+    const result = ApplyMappings(input, noTextMapping);
+    expect(result?.valueFormatted).toBe('');
+  });
+});

--- a/src/data/overrides.test.ts
+++ b/src/data/overrides.test.ts
@@ -1,0 +1,80 @@
+import { createTheme, FieldType, toDataFrame } from '@grafana/data';
+import { ApplyGrafanaOverrides } from './overrides';
+
+// Real Grafana theme so getDisplayProcessor has the visualization color
+// palette it expects. The no-op replaceVariables stub is sufficient for
+// these tests because the fieldConfig we pass into ApplyGrafanaOverrides
+// contains no template strings to interpolate — we're pinning the other
+// observable effects.
+const theme = createTheme();
+const noopReplaceVariables = (s: string) => s;
+
+describe('ApplyGrafanaOverrides', () => {
+  it('returns an empty array when the input frames are undefined', () => {
+    const result = ApplyGrafanaOverrides(
+      undefined as unknown as Parameters<typeof ApplyGrafanaOverrides>[0],
+      theme,
+      noopReplaceVariables,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('stamps decimals=4 on every field of the first returned frame', () => {
+    const df = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'value', type: FieldType.number, values: [10, 20] },
+      ],
+    });
+
+    const [out] = ApplyGrafanaOverrides([df], theme, noopReplaceVariables);
+
+    expect(out.fields).toHaveLength(2);
+    for (const field of out.fields) {
+      expect(field.config.decimals).toBe(4);
+    }
+  });
+
+  it('attaches a display function to every field on the first frame', () => {
+    const df = toDataFrame({
+      fields: [
+        { name: 'a', type: FieldType.number, values: [1] },
+        { name: 'b', type: FieldType.string, values: ['x'] },
+      ],
+    });
+
+    const [out] = ApplyGrafanaOverrides([df], theme, noopReplaceVariables);
+
+    for (const field of out.fields) {
+      expect(typeof field.display).toBe('function');
+    }
+  });
+
+  it('forwards the replaceVariables argument through to applyFieldOverrides', () => {
+    // applyFieldOverrides only calls replaceVariables when a string inside
+    // the fieldConfig contains template syntax. The helper hard-codes
+    // `defaults: {}` and `overrides: []`, so no interpolation happens in
+    // practice — but we still want to pin that the stub is wired through
+    // rather than dropped. Spy on invocation count; with no templates
+    // present the spy is never called, which is itself a contract: the
+    // override pipeline respects the no-work short-circuit.
+    const calls: string[] = [];
+    const spy = (value: string) => {
+      calls.push(value);
+      return value;
+    };
+    const df = toDataFrame({
+      fields: [{ name: 'value', type: FieldType.number, values: [1, 2] }],
+    });
+
+    ApplyGrafanaOverrides([df], theme, spy);
+
+    // The plumbing passed our spy to applyFieldOverrides; it was free to
+    // invoke it (or not). Either outcome proves we handed in OUR stub —
+    // a no-op default would have prevented any invocation. The stronger
+    // assertion is that the call completed without throwing, which it
+    // does only if the stub signature matched what applyFieldOverrides
+    // expects.
+    expect(Array.isArray(calls)).toBe(true);
+  });
+});

--- a/src/data/overrides.test.ts
+++ b/src/data/overrides.test.ts
@@ -69,12 +69,10 @@ describe('ApplyGrafanaOverrides', () => {
 
     ApplyGrafanaOverrides([df], theme, spy);
 
-    // The plumbing passed our spy to applyFieldOverrides; it was free to
-    // invoke it (or not). Either outcome proves we handed in OUR stub —
-    // a no-op default would have prevented any invocation. The stronger
-    // assertion is that the call completed without throwing, which it
-    // does only if the stub signature matched what applyFieldOverrides
-    // expects.
-    expect(Array.isArray(calls)).toBe(true);
+    // No templates in the hard-coded `defaults: {}` / `overrides: []`, so the
+    // spy must never fire — pins the no-work short-circuit of the override
+    // pipeline while also proving the plumbing accepts our stub signature
+    // (a mismatched signature would have thrown before this assertion).
+    expect(calls).toEqual([]);
   });
 });

--- a/src/data/overrides.ts
+++ b/src/data/overrides.ts
@@ -2,10 +2,15 @@ import {
   applyFieldOverrides,
   DataFrame,
   getDisplayProcessor,
-  GrafanaTheme2 } from '@grafana/data';
+  GrafanaTheme2,
+  InterpolateFunction } from '@grafana/data';
 
 
-export const ApplyGrafanaOverrides = (dataFrames: DataFrame[], theme: GrafanaTheme2) => {
+export const ApplyGrafanaOverrides = (
+  dataFrames: DataFrame[],
+  theme: GrafanaTheme2,
+  replaceVariables: InterpolateFunction,
+) => {
   let newDataFrames: DataFrame[] = [];
   if (dataFrames) {
     newDataFrames = applyFieldOverrides({
@@ -16,7 +21,7 @@ export const ApplyGrafanaOverrides = (dataFrames: DataFrame[], theme: GrafanaThe
         overrides: []
       },
       theme,
-      replaceVariables: (value: string) => value,
+      replaceVariables,
     });
     for (let i = 0; i < newDataFrames[0].fields.length; i++) {
       const aField = newDataFrames[0].fields[i];

--- a/src/data/transformations.test.ts
+++ b/src/data/transformations.test.ts
@@ -1,0 +1,140 @@
+import {
+  DataTransformerID,
+  FieldType,
+  standardTransformers,
+  standardTransformersRegistry,
+  toDataFrame,
+  TransformerRegistryItem,
+} from '@grafana/data';
+import { AggregationType, TransformationOptions } from 'types';
+import { GetDataTransformerID, getDataFrameFields, transformData } from './transformations';
+
+// Grafana's runtime populates `standardTransformersRegistry` at app startup.
+// In jest we have to seed it ourselves, otherwise `transformDataFrame` throws
+// `"<id>" not found in:` when it tries to look up `merge`, `reduce`, etc.
+beforeAll(() => {
+  standardTransformersRegistry.setInit(() => {
+    // `standardTransformers` contains deprecated aliases (e.g.
+    // `seriesToColumnsTransformer` shares an id with `joinByFieldTransformer`);
+    // Registry.setInit rejects duplicates, so keep first occurrence per id.
+    const seen = new Set<string>();
+    const items: Array<TransformerRegistryItem<any>> = [];
+    for (const t of Object.values(standardTransformers)) {
+      if (seen.has(t.id)) {
+        continue;
+      }
+      seen.add(t.id);
+      items.push({
+        id: t.id,
+        name: (t as { name?: string }).name ?? t.id,
+        transformation: t,
+        editor: () => null,
+        imageDark: '',
+        imageLight: '',
+      });
+    }
+    return items;
+  });
+});
+
+describe('GetDataTransformerID', () => {
+  it.each([
+    [TransformationOptions.JSONData, DataTransformerID.joinByField],
+    [TransformationOptions.Table, DataTransformerID.merge],
+    [TransformationOptions.TimeSeriesAggregations, DataTransformerID.reduce],
+    [TransformationOptions.TimeSeriesToColumns, DataTransformerID.joinByField],
+    [TransformationOptions.TimeSeriesToRows, DataTransformerID.seriesToRows],
+  ])('maps %s → %s', (option, expected) => {
+    expect(GetDataTransformerID(option)).toBe(expected);
+  });
+
+  it('falls back to joinByField for an unknown option', () => {
+    expect(GetDataTransformerID('unknown' as unknown as TransformationOptions)).toBe(
+      DataTransformerID.joinByField,
+    );
+  });
+});
+
+describe('getDataFrameFields', () => {
+  it('returns an empty array when given no frames', () => {
+    expect(getDataFrameFields([])).toEqual([]);
+  });
+
+  it('collects the field names of a single frame', () => {
+    const df = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1, 2] },
+        { name: 'A', type: FieldType.number, values: [10, 20] },
+      ],
+    });
+    expect(getDataFrameFields([df])).toEqual(['time', 'A']);
+  });
+
+  it('deduplicates field names across multiple frames', () => {
+    const a = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1] },
+        { name: 'A', type: FieldType.number, values: [10] },
+      ],
+    });
+    const b = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [2] },
+        { name: 'B', type: FieldType.number, values: [20] },
+      ],
+    });
+    // 'time' appears in both frames but is listed once; order preserves first-seen
+    expect(getDataFrameFields([a, b])).toEqual(['time', 'A', 'B']);
+  });
+});
+
+describe('transformData', () => {
+  // Two single-row frames with the same schema. After the `merge` transform
+  // they should collapse into one frame whose numeric column carries both
+  // rows' values. This exercises the transformation pipeline end-to-end
+  // against real `@grafana/data` code without mocking.
+  it('runs the merge transform and returns a single combined frame', async () => {
+    const a = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [1000] },
+        { name: 'value', type: FieldType.number, values: [10] },
+      ],
+    });
+    const b = toDataFrame({
+      fields: [
+        { name: 'time', type: FieldType.time, values: [2000] },
+        { name: 'value', type: FieldType.number, values: [20] },
+      ],
+    });
+
+    const result = await transformData([a, b], DataTransformerID.merge, []);
+
+    expect(result).toHaveLength(1);
+    const valueField = result[0].fields.find((f) => f.name === 'value');
+    expect(valueField?.values).toEqual([10, 20]);
+  });
+
+  // When the transform is `reduce`, transformData must inject the supplied
+  // aggregations into the transform options as `options.reducers`. This
+  // case pins that branch — passing a single `mean` reducer across a
+  // one-field numeric frame must produce one row with the mean.
+  it('passes aggregations into the reduce transform options', async () => {
+    const df = toDataFrame({
+      fields: [
+        { name: 'value', type: FieldType.number, values: [10, 20, 30] },
+      ],
+    });
+
+    const result = await transformData(
+      [df],
+      DataTransformerID.reduce,
+      [AggregationType.MEAN],
+    );
+
+    // The reduce transform produces a frame where each row corresponds to
+    // one input field; cell values are the reducer outputs.
+    expect(result).toHaveLength(1);
+    const meanField = result[0].fields.find((f) => f.name === 'Mean');
+    expect(meanField?.values).toEqual([20]);
+  });
+});

--- a/src/data/transformations.ts
+++ b/src/data/transformations.ts
@@ -35,8 +35,6 @@ export async function transformData(
     options: options,
   };
   const transformedData = transformDataFrame([transformConfig], data);
-  // TODO: fix this ignore, it works but should not be required
-  // @ts-ignore
   return await lastValueFrom(transformedData);
 }
 

--- a/src/data/valueMappings.test.ts
+++ b/src/data/valueMappings.test.ts
@@ -129,6 +129,37 @@ describe('getValueMappingResult', () => {
       const mapping = specialValue(match, { text: expected });
       expect(getValueMappingResult([mapping], input)).toEqual({ text: expected });
     });
+
+    // Each SpecialValueMatch sub-case has a `break;` path that fires when
+    // the discriminant matches but the value doesn't fit the sub-case's
+    // predicate — the outer loop then moves to the next mapping. Pin that
+    // fall-through for every sub-case.
+    it.each([
+      [SpecialValueMatch.Null, 42],
+      [SpecialValueMatch.NaN, 42],
+      [SpecialValueMatch.NullAndNaN, 42],
+      [SpecialValueMatch.True, 'not-true'],
+      [SpecialValueMatch.False, 'not-false'],
+      [SpecialValueMatch.Empty, 'not-empty'],
+    ])('%s with non-matching value falls through to the next mapping', (match, input) => {
+      const special = specialValue(match, { text: 'should-not-hit' });
+      const fallback = valueToText({ [String(input)]: { text: 'hit' } });
+      expect(getValueMappingResult([special, fallback], input)).toEqual({ text: 'hit' });
+    });
+  });
+
+  it('skips RangeToText when value is null', () => {
+    // Hits the `continue;` at the null-guard inside the RangeToText case.
+    const range = rangeToText(0, 10, { text: 'range' });
+    const fallback = specialValue(SpecialValueMatch.Null, { text: 'null-hit' });
+    expect(getValueMappingResult([range, fallback], null)).toEqual({ text: 'null-hit' });
+  });
+
+  it('skips RegexToText when value is null', () => {
+    // Hits the `continue;` at the null-guard inside the RegexToText case.
+    const regex = regexToText('/./', { text: 'regex' });
+    const fallback = specialValue(SpecialValueMatch.Null, { text: 'null-hit' });
+    expect(getValueMappingResult([regex, fallback], null)).toEqual({ text: 'null-hit' });
   });
 
   it('returns null when no mapping matches', () => {

--- a/src/data/valueMappings.test.ts
+++ b/src/data/valueMappings.test.ts
@@ -1,0 +1,174 @@
+import { MappingType, SpecialValueMatch, ValueMapping } from '@grafana/data';
+import { getValueMappingResult, isNumeric } from './valueMappings';
+
+const valueToText = (options: Record<string, { text?: string; color?: string }>): ValueMapping =>
+  ({ type: MappingType.ValueToText, options } as ValueMapping);
+
+const rangeToText = (
+  from: number | null,
+  to: number | null,
+  result: { text?: string; color?: string },
+): ValueMapping =>
+  ({
+    type: MappingType.RangeToText,
+    options: { from: from ?? undefined, to: to ?? undefined, result },
+  } as unknown as ValueMapping);
+
+const regexToText = (pattern: string, result: { text?: string }): ValueMapping =>
+  ({
+    type: MappingType.RegexToText,
+    options: { pattern, result },
+  } as unknown as ValueMapping);
+
+const specialValue = (match: SpecialValueMatch, result: { text?: string }): ValueMapping =>
+  ({
+    type: MappingType.SpecialValue,
+    options: { match, result },
+  } as unknown as ValueMapping);
+
+describe('getValueMappingResult', () => {
+  describe('ValueToText', () => {
+    it('returns the mapped result when the key exists', () => {
+      const mapping = valueToText({ online: { text: 'UP' }, offline: { text: 'DOWN' } });
+      expect(getValueMappingResult([mapping], 'online')).toEqual({ text: 'UP' });
+    });
+
+    it('returns null when the key is not in the map', () => {
+      const mapping = valueToText({ online: { text: 'UP' } });
+      expect(getValueMappingResult([mapping], 'unknown')).toBeNull();
+    });
+
+    it('skips the mapping when the value is null', () => {
+      const mapping = valueToText({ online: { text: 'UP' } });
+      expect(getValueMappingResult([mapping], null)).toBeNull();
+    });
+  });
+
+  describe('RangeToText', () => {
+    it('returns the result for a value inside the range', () => {
+      const mapping = rangeToText(0, 10, { text: 'low' });
+      expect(getValueMappingResult([mapping], 5)).toEqual({ text: 'low' });
+    });
+
+    it('returns null for a value below the range', () => {
+      const mapping = rangeToText(0, 10, { text: 'low' });
+      expect(getValueMappingResult([mapping], -1)).toBeNull();
+    });
+
+    it('returns null for a value above the range', () => {
+      const mapping = rangeToText(0, 10, { text: 'low' });
+      expect(getValueMappingResult([mapping], 11)).toBeNull();
+    });
+
+    it('skips the mapping for non-numeric input', () => {
+      const mapping = rangeToText(0, 10, { text: 'low' });
+      expect(getValueMappingResult([mapping], 'abc')).toBeNull();
+    });
+
+    it('treats an unset `from` as -Infinity', () => {
+      const mapping = rangeToText(null, 10, { text: 'low' });
+      expect(getValueMappingResult([mapping], -9999)).toEqual({ text: 'low' });
+    });
+
+    it('treats an unset `to` as +Infinity', () => {
+      const mapping = rangeToText(0, null, { text: 'high' });
+      expect(getValueMappingResult([mapping], 9999)).toEqual({ text: 'high' });
+    });
+  });
+
+  describe('RegexToText', () => {
+    it('returns the result for a matching regex, rewriting the matched substring', () => {
+      // The result text is applied via `value.replace(regex, resultText)` —
+      // the unmatched suffix is preserved and concatenated. Pinning this
+      // documents the behavior explicitly; callers who want a full-string
+      // rewrite anchor the pattern with `$` (see the capture-group case).
+      const mapping = regexToText('/^web-/', { text: 'host-' });
+      expect(getValueMappingResult([mapping], 'web-01')).toEqual({ text: 'host-01' });
+    });
+
+    it('performs capture-group replacement in the result text', () => {
+      const mapping = regexToText('/^web-(\\d+)$/', { text: 'host-$1' });
+      expect(getValueMappingResult([mapping], 'web-42')).toEqual({ text: 'host-42' });
+    });
+
+    it('returns null when the regex does not match', () => {
+      const mapping = regexToText('/^web-/', { text: 'web host' });
+      expect(getValueMappingResult([mapping], 'db-01')).toBeNull();
+    });
+
+    it('skips the mapping for non-string input', () => {
+      const mapping = regexToText('/^web-/', { text: 'web host' });
+      expect(getValueMappingResult([mapping], 42)).toBeNull();
+    });
+  });
+
+  describe('SpecialValue', () => {
+    it('matches Null when the value is null', () => {
+      const mapping = specialValue(SpecialValueMatch.Null, { text: 'N/A' });
+      expect(getValueMappingResult([mapping], null)).toEqual({ text: 'N/A' });
+    });
+
+    it('matches NaN when the value is NaN', () => {
+      const mapping = specialValue(SpecialValueMatch.NaN, { text: 'NaN' });
+      expect(getValueMappingResult([mapping], NaN)).toEqual({ text: 'NaN' });
+    });
+
+    it('matches NullAndNaN for both null and NaN', () => {
+      const mapping = specialValue(SpecialValueMatch.NullAndNaN, { text: 'missing' });
+      expect(getValueMappingResult([mapping], null)).toEqual({ text: 'missing' });
+      expect(getValueMappingResult([mapping], NaN)).toEqual({ text: 'missing' });
+    });
+
+    it.each([
+      [SpecialValueMatch.True, true, 'yes'],
+      [SpecialValueMatch.True, 'true', 'yes'],
+      [SpecialValueMatch.False, false, 'no'],
+      [SpecialValueMatch.False, 'false', 'no'],
+      [SpecialValueMatch.Empty, '', 'empty'],
+    ])('matches %s on %j', (match, input, expected) => {
+      const mapping = specialValue(match, { text: expected });
+      expect(getValueMappingResult([mapping], input)).toEqual({ text: expected });
+    });
+  });
+
+  it('returns null when no mapping matches', () => {
+    expect(getValueMappingResult([], 'anything')).toBeNull();
+  });
+
+  it('walks the list in order and returns the first match', () => {
+    const first = valueToText({ hit: { text: 'FIRST' } });
+    const second = valueToText({ hit: { text: 'SECOND' } });
+    expect(getValueMappingResult([first, second], 'hit')).toEqual({ text: 'FIRST' });
+  });
+
+  it('falls through a non-matching RegexToText to the next mapping without matching SpecialValue', () => {
+    // Pins the bug that the `case MappingType.RegexToText:` branch was
+    // missing a `break;` — before the fix, a non-matching regex would fall
+    // through and attempt to evaluate the SpecialValue inner switch against
+    // the RegexToText options (usually a no-op because `options.match` is
+    // undefined, but fragile). With the `break;` in place, the next mapping
+    // in the list is consulted cleanly.
+    const regex = regexToText('/^never-matches-/', { text: 'X' });
+    const fallback = valueToText({ '7': { text: 'lucky' } });
+    expect(getValueMappingResult([regex, fallback], '7')).toEqual({ text: 'lucky' });
+  });
+});
+
+describe('isNumeric', () => {
+  it.each([
+    [0, true],
+    [1.5, true],
+    [-10, true],
+    ['42', true],
+    ['3.14', true],
+    [' 5 ', true],
+    ['', false],
+    ['abc', false],
+    [NaN, false],
+    [null, false],
+    [undefined, false],
+    [{}, false],
+  ])('isNumeric(%j) === %s', (input, expected) => {
+    expect(isNumeric(input)).toBe(expected);
+  });
+});

--- a/src/data/valueMappings.ts
+++ b/src/data/valueMappings.ts
@@ -71,6 +71,8 @@ export function getValueMappingResult(valueMappings: ValueMapping[], value: any)
           return res;
         }
 
+        break;
+
       case MappingType.SpecialValue:
         switch ((vm.options as SpecialValueOptions).match) {
           case SpecialValueMatch.Null: {

--- a/src/data/valueMappings.ts
+++ b/src/data/valueMappings.ts
@@ -13,7 +13,7 @@ import {
 export function getValueMappingResult(valueMappings: ValueMapping[], value: any): ValueMappingResult | null {
   for (const vm of valueMappings) {
     switch (vm.type) {
-      case MappingType.ValueToText:
+      case MappingType.ValueToText: {
         if (value == null) {
           continue;
         }
@@ -24,8 +24,9 @@ export function getValueMappingResult(valueMappings: ValueMapping[], value: any)
         }
 
         break;
+      }
 
-      case MappingType.RangeToText:
+      case MappingType.RangeToText: {
         if (value == null) {
           continue;
         }
@@ -50,8 +51,9 @@ export function getValueMappingResult(valueMappings: ValueMapping[], value: any)
         }
 
         return vm.options.result;
+      }
 
-      case MappingType.RegexToText:
+      case MappingType.RegexToText: {
         if (value == null) {
           continue;
         }
@@ -72,6 +74,7 @@ export function getValueMappingResult(valueMappings: ValueMapping[], value: any)
         }
 
         break;
+      }
 
       case MappingType.SpecialValue:
         switch ((vm.options as SpecialValueOptions).match) {


### PR DESCRIPTION
## Summary

Cleanup + coverage + correctness pass across the `src/data/` utilities.

- **Correctness** — 4 bug fixes (stale `@ts-ignore`, unwired `replaceVariables`, missing `break;`, `TimeFormatter` timezone bug)
- **API cleanup** — 2 sibling helpers converted to named-options objects, 3 dead params dropped
- **Style & convention** — callback params aligned with `@typescript-eslint/no-unused-vars`, switch-case lexical scoping
- **React effects & state** — `AlignmentFlags` memoization, intentional placeholder for a disabled option's deps (see #296), `useTracker` hook landed with `ThresholdsEditor` + `ColumnStylesEditor` migrating onto it
- **Test coverage** — `src/data/` coverage **44% → 73%**, test count **78 → 216** (138 new)
- **Tooling** — `mise.toml` auto-enables corepack
- **Follow-up** — #296 tracks an architecturally-dead panel option surfaced during review

All 10 phase3 E2E specs pass. No user-facing behavior change except the `TimeFormatter` timezone fix.

---

## 1. Correctness

### `src/data/transformations.ts`

- Remove stale `// @ts-ignore` + `TODO: fix this ignore` on `lastValueFrom(transformedData)`. Current `@grafana/data` / `rxjs` versions align (both resolve to `rxjs@7.8.2`) so the call typechecks cleanly without the ignore.

### `src/data/overrides.ts`

- Wire the real `replaceVariables` into `ApplyGrafanaOverrides`. Previously passed a no-op `(value) => value` to `applyFieldOverrides`; now that PR #294 threads `props.replaceVariables` through the panel for clickthroughs, forward it here too so field-config overrides interpolate dashboard variables identically to the stock link/threshold pipelines. Plumbing: `ApplyGrafanaOverrides` → `ConvertDataFrameToDataTableFormat` → `DataTablePanel.tsx` pass-through + `useEffect` dep.

### `src/data/valueMappings.ts`

- Add the missing `break;` in `getValueMappingResult` after the `RegexToText` case. A non-matching regex previously fell through into the `SpecialValue` switch — latent in practice (inner cases all no-oped because `options.match` is `undefined` on a RegexToText config) but fragile.

### `src/data/cellRenderer.ts`

- `TimeFormatter` now actually converts to non-UTC timezones. The non-UTC branch used `moment.tz(iso, format, tz)` — the PARSING overload, which treats the input as already-local-to-tz — so a dashboard in `America/New_York` at `15:27:35 EDT` was rendering as `19:27:35` (raw UTC digits, labelled as NY local). Switched to `moment.tz(timestamp, tz)` — the CONVERSION overload that takes UTC milliseconds and returns a Moment in the target zone. Also removed a dead `let formattedWithTimezone = dateTime(...)` initialiser that was unconditionally overwritten on the next line.

---

## 2. API cleanup

### Options-object migrations

- **`ConvertDataFrameToDataTableFormat`** — 9 positional args → `ConvertDataFrameOptions`. Drops the unused `timeRange` param the prior signature carried but the function body never read.
- **`BuildColumnDefs`** — 6 positional args → `BuildColumnDefsOptions`, matching the `ConvertDataFrameOptions` precedent so the sibling helpers share a call shape.

Both call sites in `DataTablePanel.tsx` updated — each option now named at the call site instead of depending on positional order.

### Dead-param drops

- **`getCellColors`** loses the unused `columnNumber` middle arg (3 call sites + 7 test sites updated). The `actualColumn = colIndex - (rowNumbersEnabled ? 1 : 0)` offset in the `createdCell` callback fed only that removed arg and is gone too.
- **`BuildColumnDefs`** loses unused `emptyDataEnabled` / `emptyDataText` params. The options never had a runtime consumer — the commented-out `defaultContent: emptyDataEnabled ? emptyDataText : ''` was the only code that had ever read them, and wiring them up conflicts with the existing `data:` / `render:` pipeline. Remediation tracked in **#296**.

---

## 3. Style & convention

- **Datatables.net `data:` / `render:` callback unused params** renamed to `_set` / `_data` per the `@typescript-eslint/no-unused-vars` convention, preserving the library-dictated positional signatures.
- **`getValueMappingResult` switch cases block-scoped** to resolve `no-case-declarations` on `ValueToText`, `RangeToText`, `RegexToText`.

---

## 4. React effects & state

- **`AlignmentFlags` memoization.** The `{ numbers, strings }` literal is now `useMemo`-ed keyed on the two panel booleans. Three `useEffect` dep arrays depend on the memoized reference instead of the raw primitives — same re-run cadence per toggle, but the stable-identity invariant is now enforced by reference equality rather than convention.
- **`emptyData*` deps placeholder.** `props.options.emptyDataEnabled` / `emptyDataText` stay in both `useEffect` dep arrays in `DataTablePanel.tsx` even though neither effect reads them today. Each site carries a comment explaining the deps are placeholders for the **#296** option-B remediation that would wire the option into `defaultContent`.
- **`useTracker` hook** (`src/hooks/useTracker.ts`) + migrations of `ThresholdsEditor` and `ColumnStylesEditor` onto it. Immutable state, functional setters, per-row `isOpen` keyed by tracker `ID` (fixes a latent pre-refactor bug where remove/reorder smeared open state onto neighbors in `ColumnStylesEditor`).

---

## 5. Test coverage & quality

`src/data/` unit coverage: **44% → 73%**. Test count: **78 → 216** (138 new).

### New files

| File | Cases | Focus |
|---|---|---|
| `src/data/transformations.test.ts` | 11 | `GetDataTransformerID` enum mappings, `getDataFrameFields` dedup, `transformData` merge + reduce. Seeds `standardTransformersRegistry` in `beforeAll`. |
| `src/data/overrides.test.ts` | 4 | `ApplyGrafanaOverrides`: undefined-input guard, `decimals = 4` stamping, `display` function attached post-pass, `replaceVariables` forwarded through. |
| `src/data/valueMappings.test.ts` | 44 | `getValueMappingResult` across every `MappingType` branch, ordered iteration, fall-through regression pin for `RegexToText`, every `SpecialValueMatch` sub-case, null-value short-circuits. Plus `isNumeric` parameterized across 12 inputs. |
| `src/data/mappingProcessor.test.ts` | 9 | `GetMappings` precedence; `ApplyMappings` null-guard, no-raw-guard, no-match, in-place mutation, empty-string fallback. |
| `src/data/columnAliasing.test.ts` | 7 | `ApplyColumnAliases`. |
| `src/data/columnWidthHints.test.ts` | 7 | `ApplyColumnWidthHints`. |

### Extensions to existing files

| File | +Cases | Focus |
|---|---|---|
| `src/data/cellRenderer.test.ts` | +25 | `ReplaceTimeMacros`, `ReplaceCellMacros`, `ReplaceCellSplitByPattern`, `resolveClickThroughTarget`, `TimeFormatter` (incl. real UTC→EDT conversion + `browser` zone). `FormatColumnValue` string / DATE style / metric style. `ProcessClickthrough` `splitByPattern` + `clickThroughSanitize`. `applyFormat` currency-prefix. |
| `src/data/dataHelpers.test.ts` | +30 | `GetColorForValue`, `GetColorIndexForValue`, `getCellColors` across colorMode branches. `ConvertDataFrameToDataTableFormat` field→column shape, row-object build, `rowNumbersEnabled`, HIDDEN-style visibility. `BuildColumnDefs` options-object API + the `{ targets: '_all', defaultContent: '-' }` DataTables sentinel. |
| `src/data/columnStyles.test.ts` | +4 | regex-slash path (match, no-match, first-style-wins) + un-slashed `nameOrRegex` exact-string match. |

### Test-quality sharpening

- **`asRecord(d)` helper** in the `BuildColumnDefs` test factors out the four repeated `as unknown as Record<string, unknown>` casts into one describe-scoped helper. DataTables' `ConfigColumnDefs` is a narrow union with no index signature, so probing runtime properties needs the bounce through `unknown`.
- **`overrides.test.ts` no-work assertion** — previous `expect(Array.isArray(calls)).toBe(true)` was tautological (the array was declared as `[]` in scope). Replaced with `expect(calls).toEqual([])` so the test actually pins the short-circuit contract.
- **`cellRenderer.test.ts` epoch constant** — hoisted the reused `1744486055000` timestamp (5 call sites) into a file-scope `EPOCH_2025_04_12T19_27_35Z` so the human-readable date reads off the identifier.

---

## 6. Tooling

- `mise.toml` — `node` tool entry now carries `postinstall = "corepack enable"` so a fresh `mise install` auto-activates corepack and `pnpm` resolves to the declared `packageManager` version without a manual step.

---

## 7. Follow-ups

- **#296** — `emptyDataEnabled` / `emptyDataText` panel options are surfaced in the editor but unreachable at runtime. Two remediation paths documented in the issue (remove the UI, or rework `data:` / `render:` / `defaultContent`). Unblocked this PR.

---

## 8. CHANGELOG

Entries live under `## [Unreleased]` → `### Refactoring`, grouped into h4 sub-sections mirroring the PR body: Correctness, Test coverage & quality, API cleanup, Style & convention, React effects & state.

---

## 9. Verification

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 216 unit tests pass (78 before this PR + 138 new)
- [x] `pnpm e2e` — 10 phase3 E2E tests pass (`clickthrough-urls`, `column-filter-alignment`, `column-filter-many-columns`, `create-panel`, `text-alignment-panel-level`, `text-alignment`, `thresholds-color`)
- [x] `src/data/` coverage: 44% → 73%