### PR TITLE
ci: SHA-pin pnpm/action-setup and actions/setup-node in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           persist-credentials: false
       # pnpm action uses the packageManager field in package.json to
       # understand which version to install.
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Setup Node.js environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -177,9 +177,9 @@ jobs:
         run: |
           chmod +x ./dist/gpx_*
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
       - name: Setup Node.js environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

- SHA-pin the remaining floating-tag references in `.github/workflows/ci.yml`:
  - `pnpm/action-setup@v4` → `@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0` (2 call sites)
  - `actions/setup-node@v6` → `@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0` (2 call sites)
- Matches the SHAs already used in `is-compatible.yml` and (partially) `coverage.yml`. Completes the create-plugin 7.1.7 migration, which SHA-pinned these two actions in the other workflows but missed `ci.yml`.

## Why

The repo's existing pattern (enforced by zizmor / Grafana best-practice) is to pin third-party actions to commit hashes so that a compromised tag can't hijack CI. Four floating-tag holdouts in `ci.yml` broke that pattern.

No behavior change — the pinned commit IDs resolve to the same versions the floating tags currently point to (v4.2.0 / v6.2.0).

## Test plan

- [ ] CI passes green on this branch (all quality gates)
- [ ] Workflow logs confirm the same pnpm / Node versions as before