### PR TITLE
docs(readme): remove dead Snyk vulnerabilities badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 ![Downloads](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgrafana.com%2Fapi%2Fplugins%2Fbriangann-datatable-panel&query=downloads&logo=grafana&label=Downloads&color=orange)
 [![License](https://img.shields.io/github/license/briangann/grafana-datatable-panel)](LICENSE)
 ![CI (main)](https://github.com/briangann/grafana-datatable-panel/actions/workflows/ci.yml/badge.svg?branch=main)
-
-[![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
 ![Release](https://github.com/briangann/grafana-datatable-panel/workflows/Release/badge.svg)
+[![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
 
 This panel plugin provides a [Datatables.net](http://www.datatables.net) table panel
 for [Grafana](http://www.grafana.com) 10.x/11.x/12.x.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
 ![Release](https://github.com/briangann/grafana-datatable-panel/workflows/Release/badge.svg)
 
-[![Known Vulnerabilities](https://snyk.io/test/github/briangann/grafana-datatable-panel/badge.svg)](https://snyk.io/test/github/briangann/grafana-datatable-panel)
-
 This panel plugin provides a [Datatables.net](http://www.datatables.net) table panel
 for [Grafana](http://www.grafana.com) 10.x/11.x/12.x.
 


### PR DESCRIPTION
## Summary

- The Snyk public badge endpoint `https://snyk.io/test/github/<org>/<repo>/badge.svg` now returns HTTP 410 Gone with body `{"error":"This endpoint is no longer available."}`, so the README was rendering a broken image.
- Dependabot is already active on this repo and surfaces vulnerabilities directly in the GitHub Security tab, so no replacement badge is needed.

## Verification

```
curl -sI https://snyk.io/test/github/briangann/grafana-datatable-panel/badge.svg
# HTTP/2 410
curl -s  https://snyk.io/test/github/briangann/grafana-datatable-panel/badge.svg
# {"error":"This endpoint is no longer available."}
```

## Test plan

- [ ] Confirm README preview on GitHub no longer shows a broken image
- [ ] Existing CI / Version / Downloads / License / Release badges still render