### PR TITLE
deps: bump uuid 11.1.0 → 13.0.0 and drop @types/uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/node": "^24.12.2",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
     "all-contributors-cli": "^6.26.1",
@@ -129,7 +128,7 @@
     "react-dom": "^18.3.0",
     "rxjs": "^7.8.1",
     "tslib": "2.8.1",
-    "uuid": "^11.0.5"
+    "uuid": "^13.0.0"
   },
   "packageManager": "pnpm@10.11.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: 2.8.1
         version: 2.8.1
       uuid:
-        specifier: ^11.0.5
-        version: 11.1.0
+        specifier: ^13.0.0
+        version: 13.0.0
     devDependencies:
       '@babel/core':
         specifier: ^7.29.0
@@ -171,9 +171,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.28)
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.3.0
         version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.8.3))(eslint@9.39.4)(typescript@5.8.3)
@@ -1686,9 +1683,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
-
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -7558,8 +7552,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/use-sync-external-store@0.0.6': {}
-
-  '@types/uuid@10.0.0': {}
 
   '@types/yargs-parser@21.0.3': {}
 


### PR DESCRIPTION
## Summary

- `uuid` 11.1.0 → 13.0.0
- `@types/uuid` 10.0.0 → removed (uuid v13 ships its own types inline)

## Why safe

Only two call sites in the repo use `uuid`, both as the standard named import:

```
src/components/options/thresholds/ThresholdsEditor.tsx:4:import { v4 as UUIdv4 } from 'uuid';
src/components/options/columnstyles/ColumnStylesEditor.tsx:3:import { v4 as UUIdv4 } from 'uuid';
```

That import has been stable across v11 / v12 / v13, so no code changes are needed. The v12 and v13 major bumps were bin-tool and ESM-export refinements that don't affect the named `v4` import used here.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:ci` — 227/227 pass
- [x] `pnpm lint` — 0 errors (9 pre-existing `Select`/`collapsible` deprecation warnings)
- [x] `pnpm build` — succeeds