### PR TITLE
chore: add Renovate config (replace Dependabot version updates)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "America/New_York",
+  "schedule": ["before 4am on Monday"],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 4,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 4am on Monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Block @grafana/*@13.x until the grafanaDependency upper bound in plugin.json is raised past <13.0.0.",
+      "matchPackageNames": ["@grafana/**"],
+      "allowedVersions": "<13.0.0"
+    },
+    {
+      "description": "Group non-major devDependency bumps into one weekly PR.",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dev-deps (non-major)"
+    },
+    {
+      "description": "Group non-major dependency bumps into one weekly PR.",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "prod-deps (non-major)"
+    },
+    {
+      "description": "Keep all datatables.net-*-jqui packages aligned so they bump together.",
+      "matchPackageNames": ["datatables.net-*-jqui"],
+      "groupName": "datatables jqui"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a `renovate.json` at the repo root so we can switch from Dependabot version updates to Renovate. The key reason: Dependabot does not open PRs for pnpm transitive dependency updates, but Renovate does (via `lockFileMaintenance`).

## What this config does

- **Weekly schedule** (Monday before 4am ET) — no weekday PR churn.
- **`lockFileMaintenance: enabled`** — regenerates `pnpm-lock.yaml` once a week to pick up compatible transitive bumps with no `package.json` changes. This is the feature Dependabot lacks.
- **Grafana guardrail** — `@grafana/*@13.x` bumps are blocked until the `grafanaDependency` upper bound in `plugin.json` is raised past `<13.0.0` (Grafana 13 stable + matching `@grafana/ui@13.x`).
- **Grouping** — non-major `devDependency` and `dependency` bumps fold into two weekly PRs instead of one PR per package.
- **DataTables jqui lockstep** — all `datatables.net-*-jqui` packages bump in the same PR.
- **PR caps** — 10 concurrent, 4/hour.

Dependabot **security alerts** stay on (they're passive and integrate with the GitHub Security tab). Dependabot **security-update PRs** (when they trigger) also stay on — those fire on CVEs, are rare, and high-signal. No `.github/dependabot.yml` exists on this repo, so there's no version-update config to remove.

## Post-merge steps (owner must do)

1. Install the Mend-hosted Renovate GitHub App: https://github.com/apps/renovate → grant access to this repo.
2. Renovate will open a **Dependency Dashboard** issue listing every pending update; pick which to promote to PRs.
3. Subsequent Monday-morning runs will batch updates per the `packageRules` above.

## Test plan

- [ ] Config validates (Renovate will surface errors as a config warning issue if the schema is wrong)
- [ ] After the app is installed, confirm a Dependency Dashboard issue appears
- [ ] Confirm the first weekly run respects the `@grafana/**` block