### PR TITLE
chore(renovate): make vulnerability-update behavior explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Release](https://github.com/briangann/grafana-datatable-panel/workflows/Release/badge.svg)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?logo=renovatebot)](https://docs.renovatebot.com/)
 [![Renovate Dashboard](https://img.shields.io/badge/renovate-dashboard-%23007ACC?logo=renovatebot)](https://github.com/briangann/grafana-datatable-panel/issues?q=is%3Aissue+is%3Aopen+author%3Aapp%2Frenovate+in%3Atitle+%22Dependency+Dashboard%22)
-[![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
+[![Follow on X](https://img.shields.io/badge/follow-%40jepetlefeu-black?logo=x)](https://x.com/jepetlefeu)
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors)
 
 This panel plugin provides a [Datatables.net](http://www.datatables.net) table panel

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![License](https://img.shields.io/github/license/briangann/grafana-datatable-panel)](LICENSE)
 ![CI (main)](https://github.com/briangann/grafana-datatable-panel/actions/workflows/ci.yml/badge.svg?branch=main)
 ![Release](https://github.com/briangann/grafana-datatable-panel/workflows/Release/badge.svg)
-[![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
-[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?logo=renovatebot)](https://docs.renovatebot.com/)
 [![Renovate Dashboard](https://img.shields.io/badge/renovate-dashboard-%23007ACC?logo=renovatebot)](https://github.com/briangann/grafana-datatable-panel/issues?q=is%3Aissue+is%3Aopen+author%3Aapp%2Frenovate+in%3Atitle+%22Dependency+Dashboard%22)
+[![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
+[![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors)
 
 This panel plugin provides a [Datatables.net](http://www.datatables.net) table panel
 for [Grafana](http://www.grafana.com) 10.x/11.x/12.x.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 ![Release](https://github.com/briangann/grafana-datatable-panel/workflows/Release/badge.svg)
 [![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors)
+[![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?logo=renovatebot)](https://docs.renovatebot.com/)
+[![Renovate Dashboard](https://img.shields.io/badge/renovate-dashboard-%23007ACC?logo=renovatebot)](https://github.com/briangann/grafana-datatable-panel/issues/309)
 
 This panel plugin provides a [Datatables.net](http://www.datatables.net) table panel
 for [Grafana](http://www.grafana.com) 10.x/11.x/12.x.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/jepetlefeu.svg?style=social)](https://twitter.com/jepetlefeu)
 [![All Contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat-square)](#contributors)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg?logo=renovatebot)](https://docs.renovatebot.com/)
-[![Renovate Dashboard](https://img.shields.io/badge/renovate-dashboard-%23007ACC?logo=renovatebot)](https://github.com/briangann/grafana-datatable-panel/issues/309)
+[![Renovate Dashboard](https://img.shields.io/badge/renovate-dashboard-%23007ACC?logo=renovatebot)](https://github.com/briangann/grafana-datatable-panel/issues?q=is%3Aissue+is%3Aopen+author%3Aapp%2Frenovate+in%3Atitle+%22Dependency+Dashboard%22)
 
 This panel plugin provides a [Datatables.net](http://www.datatables.net) table panel
 for [Grafana](http://www.grafana.com) 10.x/11.x/12.x.

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,15 @@
     "enabled": true,
     "schedule": ["before 4am on Monday"]
   },
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security"],
+    "prPriority": 10,
+    "schedule": ["at any time"],
+    "commitMessagePrefix": "security:",
+    "minimumReleaseAge": null
+  },
   "packageRules": [
     {
       "description": "Block @grafana/*@13.x until the grafanaDependency upper bound in plugin.json is raised past <13.0.0.",


### PR DESCRIPTION
## Summary

Renovate's `config:recommended` preset already enables vulnerability alerts, but the defaults bury security PRs inside the same weekly schedule as routine bumps. This tightens the behavior so security fixes actually arrive promptly and are easy to spot — directly replacing the Dependabot security-update PRs we're disabling repo-side.

## What changes in `renovate.json`

```json
"osvVulnerabilityAlerts": true,
"vulnerabilityAlerts": {
  "enabled": true,
  "labels": ["dependencies", "security"],
  "prPriority": 10,
  "schedule": ["at any time"],
  "commitMessagePrefix": "security:",
  "minimumReleaseAge": null
}
```

| Setting | Effect |
|---|---|
| `vulnerabilityAlerts.enabled: true` | Explicit; was implicit via preset before. |
| `schedule: ["at any time"]` | Override the weekly `before 4am on Monday` schedule — security PRs fire immediately when an advisory lands. |
| `prPriority: 10` | Jump the queue past other open Renovate PRs. |
| `labels: ["dependencies", "security"]` | Distinct label from routine bumps; easy to filter in the PR list. |
| `commitMessagePrefix: "security:"` | Distinct prefix in git log / CHANGELOG; plays nicely with Conventional Commits. |
| `minimumReleaseAge: null` | Cancel any future preset-inherited release-age delay; we want fixes immediately. |
| `osvVulnerabilityAlerts: true` | Read OSV.dev as a second advisory feed in addition to GitHub's. Catches vulnerabilities earlier when only one database has picked them up. |

## Test plan

- [ ] Renovate bot accepts the schema (no config-validation issue opened)
- [ ] Dependency Dashboard issue reflects the new config after the next scan
- [ ] First CVE-driven PR (when one lands) uses the `security:` prefix and `security` label