### PR TITLE
ci: cancel superseded PR runs across PR-triggered workflows

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
 
+# Cancel superseded PR runs when new commits land; let push-to-main runs finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# Cancel superseded PR runs when new commits land; let push-to-main runs finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,11 @@ name: Coverage Report
 on:
   pull_request:
 
+# Cancel superseded PR runs when new commits land.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -1,6 +1,11 @@
 name: Latest Grafana API compatibility check
 on: [pull_request]
 
+# Cancel superseded PR runs when new commits land.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   compatibilitycheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-files.yml
+++ b/.github/workflows/pr-files.yml
@@ -3,6 +3,11 @@ name: PR File Changes
 on:
   pull_request:
 
+# Cancel superseded PR runs when new commits land.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
## Summary

Adds a workflow-level `concurrency` block to every PR-triggered workflow so that when a PR branch receives multiple pushes in quick succession, the older in-progress run cancels automatically instead of running to completion.

## What changes

| Workflow | Trigger | Cancel on new push? |
|---|---|---|
| `ci.yml` | PR + push-to-main | PRs only — main runs finish |
| `coverage.yml` | PR | Yes |
| `is-compatible.yml` | PR | Yes |
| `bundle-stats.yml` | PR + push-to-main + dispatch | PRs only — main runs finish |
| `pr-files.yml` | PR | Yes |

Each workflow gets this block (with `cancel-in-progress: true` or a guarded variant for the two that also run on push-to-main):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Grouping by `<workflow>-<ref>` means:

- Two pushes to the same PR branch → older run cancels.
- PR run and push-to-main run never share a group, so they don't interfere.
- Different workflows on the same ref don't interfere with each other.

## Skipped on purpose

- **`release.yml`** — never cancel a tag-triggered release mid-publish.
- **`cp-update.yml`** — scheduled create-plugin update; let it finish.

## Why

Private-repo CI-minute burn comes disproportionately from force-push storms and rebase thrashing. On this public repo the billing impact is zero (public repos are uncapped), but the same rationale applies:

- Less wall-clock waiting for the real answer on the tip commit.
- Fewer stale PR check badges.
- Reduced queue pressure for everyone else using shared runners.

## Test plan

- [ ] After merge, push two commits to a test PR ~20s apart; confirm the first run shows as "cancelled" and only the second completes.
- [ ] Push two commits to `main` rapid-fire; confirm both CI and Bundle Stats runs finish (not cancelled), preserving main-branch history.