### PR TITLE
ci: SHA-pin remaining third-party actions + add timeout-minutes to every job

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -19,6 +19,7 @@ permissions: {}
 jobs:
   compare:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -26,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     name: Build, lint and unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     outputs:
@@ -29,7 +30,7 @@ jobs:
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       # pnpm action uses the packageManager field in package.json to
@@ -63,21 +64,21 @@ jobs:
 
       - name: Setup Go environment
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
         with:
           version: latest
           args: coverage
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3.1.0
         with:
           version: latest
           args: buildAll
@@ -126,7 +127,7 @@ jobs:
             grafana/plugin-validator-cli -analyzer=metadatavalid /archive.zip
 
       - name: Archive Build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
           path: ${{ steps.metadata.outputs.plugin-id }}
@@ -144,7 +145,7 @@ jobs:
       matrix: ${{ steps.resolve-versions.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Resolve Grafana E2E versions
@@ -167,12 +168,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Download plugin
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
@@ -227,7 +228,7 @@ jobs:
 
       # Uncomment this step to upload the server log to Github artifacts. Remember Github artifacts are public on the Internet if the repository is public.
       - name: Upload server log
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ always() && steps.run-tests.outcome == 'failure' }}
         with:
           name: ${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}-server-log
@@ -238,11 +239,12 @@ jobs:
     if: ${{ always() && !cancelled() }}
     needs: [playwright-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write # deploy-report-pages pushes to gh-pages
       pull-requests: write # deploy-report-pages manages a PR summary comment
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # deploy-report-pages authenticates via its own github-token input
           # and runs a nested checkout of gh-pages; persisting credentials

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,7 @@ jobs:
   coverage:
     name: Jest Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -24,7 +25,7 @@ jobs:
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
       - name: Setup Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -15,6 +15,7 @@ permissions: {}
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # The action authenticates via the GH_PAT_TOKEN passed below; the
     # default GITHUB_TOKEN is not used, so no workflow-granted scopes
     # are needed. The elevated permissions referenced in the comment

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -9,10 +9,11 @@ concurrency:
 jobs:
   compatibilitycheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-files.yml
+++ b/.github/workflows/pr-files.yml
@@ -14,6 +14,7 @@ jobs:
   file-changes:
     name: File Changes Summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,13 @@ permissions: read-all
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       id-token: write # new line
       contents: write # new line
       attestations: write # new line
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - uses: grafana/plugin-actions/build-plugin@build-plugin/v1.0.2


### PR DESCRIPTION
## Summary

Two hardening changes bundled. No behavior change — pinned SHAs match the floating-tag tips, and timeouts are all well above the longest observed runtime for each job.

## SHA pins (finishes work started in #302)

| Action | From | To |
|---|---|---|
| `actions/checkout` | `@v6` | `@de0fac2e…` `# v6` (5 files) |
| `actions/setup-go` | `@v6` | `@4a360112…` `# v6.4.0` |
| `actions/upload-artifact` | `@v7` | `@043fb46d…` `# v7.0.1` |
| `actions/download-artifact` | `@v8` | `@3e5f45b2…` `# v8.0.1` |
| `magefile/mage-action` | `@v3` | `@6f50bbb8…` `# v3.1.0` |
| `actions/setup-node` (coverage.yml only) | `@53b83947…` `# v6` | `@6044e13b…` `# v6.2.0` |

The setup-node normalization aligns `coverage.yml` with the v6.2.0 SHA already in `ci.yml` and `is-compatible.yml`; the prior SHA pointed at a different v6 commit.

`grafana/plugin-actions/*` (Grafana-owned, subpath-tagged like `bundle-size/v1.0.2`) left as-is for now.

## Timeouts

GitHub's default job timeout is **6 hours**. Longest observed job on this repo is ~2.5 min, so there's ample headroom without risk of legitimate runs being killed.

| Workflow | Job | timeout-minutes |
|---|---|---|
| `ci.yml` | `build` | **15** |
| `ci.yml` | `resolve-versions` | 3 (already set) |
| `ci.yml` | `playwright-tests` | 15 (already set) |
| `ci.yml` | `publish-report` | **5** |
| `coverage.yml` | `coverage` | **10** |
| `is-compatible.yml` | `compatibilitycheck` | **10** |
| `bundle-stats.yml` | `compare` | **10** |
| `pr-files.yml` | `file-changes` | **5** |
| `cp-update.yml` | `release` | **20** |
| `release.yml` | `release` | **20** |

Protects against a single hung step burning 6 hours of runner time per PR. On this public repo the 2000-minute cap does not apply, but the fail-fast signal is still valuable and the pattern transfers to your private repos.

## Test plan

- [ ] After merge, push a PR change and confirm CI still passes cleanly (pins resolve, no timeouts hit)
- [ ] Tag a release and confirm `release.yml` still publishes under the 20-min cap