### PR TITLE
ci: add zizmor + actionlint workflow for Actions hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           if [ -f "Magefile.go" ]
           then
-            echo "has-backend=true" >> $GITHUB_OUTPUT
+            echo "has-backend=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Go environment
@@ -88,13 +88,15 @@ jobs:
         run: |
           if [ -f "playwright.config.ts" ]
           then
-            echo "has-e2e=true" >> $GITHUB_OUTPUT
+            echo "has-e2e=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Warn missing Grafana access policy token
+        env:
+          REPO: ${{ github.repository }}
         run: |
-          echo Please generate a Grafana access policy token: https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token
-          echo Once done please follow the instructions found here: https://github.com/${{github.repository}}/blob/main/README.md#using-github-actions-release-workflow
+          echo "Please generate a Grafana access policy token: https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token"
+          echo "Once done please follow the instructions found here: https://github.com/${REPO}/blob/main/README.md#using-github-actions-release-workflow"
         if: ${{ env.GRAFANA_ACCESS_POLICY_TOKEN == '' }}
 
       - name: Sign plugin
@@ -106,13 +108,15 @@ jobs:
         run: |
           sudo apt-get install jq
 
-          export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
-          export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
-          export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
+          GRAFANA_PLUGIN_ID=$(jq -r .id dist/plugin.json)
+          GRAFANA_PLUGIN_VERSION=$(jq -r .info.version dist/plugin.json)
+          GRAFANA_PLUGIN_ARTIFACT="${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip"
 
-          echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
-          echo "plugin-version=${GRAFANA_PLUGIN_VERSION}" >> $GITHUB_OUTPUT
-          echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
+          {
+            echo "plugin-id=${GRAFANA_PLUGIN_ID}"
+            echo "plugin-version=${GRAFANA_PLUGIN_VERSION}"
+            echo "archive=${GRAFANA_PLUGIN_ARTIFACT}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Package plugin
         id: package-plugin
@@ -121,9 +125,11 @@ jobs:
           zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
 
       - name: Check plugin.json
+        env:
+          ARCHIVE: ${{ steps.metadata.outputs.archive }}
         run: |
           docker run --pull=always \
-            -v $PWD/${{ steps.metadata.outputs.archive }}:/archive.zip \
+            -v "$PWD/${ARCHIVE}:/archive.zip" \
             grafana/plugin-validator-cli -analyzer=metadatavalid /archive.zip
 
       - name: Archive Build

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -38,7 +38,7 @@ jobs:
         id: find-module-ts
         run: |
           MODULETS="$(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \))"
-          echo "modulets=${MODULETS}" >> $GITHUB_OUTPUT
+          echo "modulets=${MODULETS}" >> "$GITHUB_OUTPUT"
 
       - name: Compatibility check
         uses: grafana/plugin-actions/is-compatible@is-compatible/v1.0.2

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,45 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+# Cancel superseded PR runs when new commits land; let push-to-main runs finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary

Adds `.github/workflows/lint-actions.yml` that runs two static analyzers over every PR touching `.github/workflows/**` (and on push-to-main under the same paths).

## What each tool catches

**actionlint** (`raven-actions/actionlint@v2.1.2`)
- YAML syntax errors, invalid `needs:` / output references
- Bad event names, typos in `if:` conditions
- `${{ }}` expression issues
- Shellcheck warnings inside `run:` steps

**zizmor** (`zizmorcore/zizmor-action@v0.5.3`)
- Unpinned third-party actions
- Overly-broad permissions
- Dangerous `pull_request_target` patterns
- `curl | bash` install idioms
- Template-injection risks in `run:` blocks
- Secret-exposure patterns

## Workflow hardening

Inherits the convention established in #302 / #313:

- Workflow-level `permissions: {}`; narrow per-job `contents: read` only
- `persist-credentials: false` on every checkout
- Actions SHA-pinned with version-commented fallback
- Concurrency `cancel-in-progress` guarded to `pull_request` events
- `timeout-minutes: 5` (both tools finish in seconds; 5 is a wide safety net)
- `paths:` gating — zero overhead on source-only PRs

## Test plan

- [ ] This PR's own CI should run `lint-actions.yml` (since `lint-actions.yml` is inside `.github/workflows/**`) and exit clean, or surface fixable findings
- [ ] Any findings get fixed as follow-up commits on this same branch
- [ ] After merge, verify a docs-only PR does not trigger this workflow (confirming the `paths:` gate works)