### PR TITLE
deps: pin all @grafana/* to exact 12.4.2; drop pnpm override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,8 +122,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Dependencies
 
-- Pin `@grafana/runtime` to 12.4.2 via pnpm override
-  (upstream 12.4.3 declares `@grafana/ui@12.4.3`, which was never published)
+- Pin every direct `@grafana/*` dependency to exact `12.4.2`; drop
+  the `pnpm.overrides` workaround for `@grafana/runtime@12.4.3`
+  (unpublished `@grafana/ui@12.4.3` peer).
 - Bump 31 dependencies to latest within current major: `@babel/core`, `@emotion/css`,
   `@grafana/tsconfig`, `@playwright/test`, `@swc/core`, `@swc/helpers`, `@swc/jest`,
   `@testing-library/jest-dom`, `@types/lodash`, `@types/pdfmake`,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
-    "@grafana/e2e-selectors": "^12.4.3",
+    "@grafana/e2e-selectors": "12.4.2",
     "@grafana/eslint-config": "^9.0.0",
     "@grafana/plugin-e2e": "^3.5.1",
     "@grafana/plugin-meta-extractor": "^0.0.3",
@@ -95,11 +95,11 @@
   },
   "dependencies": {
     "@emotion/css": "11.13.5",
-    "@grafana/data": "^12.2.0",
-    "@grafana/i18n": "^12.2.0",
-    "@grafana/runtime": "^12.2.0",
-    "@grafana/schema": "^12.2.0",
-    "@grafana/ui": "^12.2.0",
+    "@grafana/data": "12.4.2",
+    "@grafana/i18n": "12.4.2",
+    "@grafana/runtime": "12.4.2",
+    "@grafana/schema": "12.4.2",
+    "@grafana/ui": "12.4.2",
     "@types/jquery": "^3.5.29",
     "@types/pdfmake": "^0.3.2",
     "datatables.mark.js": "^2.1.0",
@@ -130,10 +130,5 @@
     "tslib": "2.8.1",
     "uuid": "^13.0.0"
   },
-  "packageManager": "pnpm@10.11.0",
-  "pnpm": {
-    "overrides": {
-      "@grafana/runtime": "12.4.2"
-    }
-  }
+  "packageManager": "pnpm@10.11.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@grafana/runtime': 12.4.2
-
 importers:
 
   .:
@@ -15,19 +12,19 @@ importers:
         specifier: 11.13.5
         version: 11.13.5
       '@grafana/data':
-        specifier: ^12.2.0
-        version: 12.4.3(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        specifier: 12.4.2
+        version: 12.4.2(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@grafana/i18n':
-        specifier: ^12.2.0
-        version: 12.4.3(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        specifier: 12.4.2
+        version: 12.4.2(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@grafana/runtime':
         specifier: 12.4.2
         version: 12.4.2(@openfeature/web-sdk@1.7.3(@openfeature/core@1.9.2))(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@grafana/schema':
-        specifier: ^12.2.0
-        version: 12.4.3
+        specifier: 12.4.2
+        version: 12.4.2
       '@grafana/ui':
-        specifier: ^12.2.0
+        specifier: 12.4.2
         version: 12.4.2(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@types/jquery':
         specifier: ^3.5.29
@@ -121,8 +118,8 @@ importers:
         specifier: ^7.29.0
         version: 7.29.0
       '@grafana/e2e-selectors':
-        specifier: ^12.4.3
-        version: 12.4.3
+        specifier: 12.4.2
+        version: 12.4.2
       '@grafana/eslint-config':
         specifier: ^9.0.0
         version: 9.0.0(@stylistic/eslint-plugin-ts@2.13.0(eslint@9.39.4)(typescript@5.8.3))(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.8.3))(eslint@9.39.4)(typescript@5.8.3))(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.8.3))(eslint-config-prettier@8.10.2(eslint@9.39.4))(eslint-plugin-jsdoc@51.4.1(eslint@9.39.4))(eslint-plugin-react-hooks@7.1.1(eslint@9.39.4))(eslint-plugin-react@7.37.5(eslint@9.39.4))(eslint@9.39.4)(typescript@5.8.3)
@@ -464,10 +461,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.27.1':
-    resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
@@ -594,14 +587,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@floating-ui/core@1.6.9':
-    resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
-
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
-
-  '@floating-ui/dom@1.6.13':
-    resolution: {integrity: sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==}
 
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
@@ -620,9 +607,6 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@floating-ui/utils@0.2.9':
-    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
   '@formatjs/ecma402-abstract@2.3.3':
     resolution: {integrity: sha512-pJT1OkhplSmvvr6i3CWTPvC/FGC06MbN5TNBfRO6Ox62AEz90eMq+dVvtX9Bl3jxCEkS0tATzDarRZuOLw7oFg==}
@@ -657,17 +641,8 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@grafana/data@12.4.3':
-    resolution: {integrity: sha512-XEZcD95AFJhWKKcPuinVkQFTkYPmlrFJv0jjsl8O23i0Bvdz27s8gvUGIU8uq1ugx/r3kxNDYCnftJLal8IKYA==}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@grafana/e2e-selectors@12.4.2':
     resolution: {integrity: sha512-Kx2joGz/jql32HgD6+pJTHRkAGL7rJC+WE+fl/wZFThmQUIGpuJjwJYL0aOmYvOZeWwVLFnyrFCiNs48s3AZJg==}
-
-  '@grafana/e2e-selectors@12.4.3':
-    resolution: {integrity: sha512-YCNFnWT+l34mgR2v9eujGwDKRZ9Q6hfA++WcqblLHnZ4Vbmy5Na6C0NJobzsyzNAczr/NbUH9XW+0DhVeKYhBg==}
 
   '@grafana/e2e-selectors@13.1.0-24448182242':
     resolution: {integrity: sha512-C8VxaFh4PGWhPBOwol3Fo0UBp1//7XNnjg7WG+t3p0P8Q2cw5HZ2NgQt1OFq9radjmWEc3DJQZvxoelI4TIOJA==}
@@ -698,11 +673,6 @@ packages:
     peerDependencies:
       react: '>=18'
 
-  '@grafana/i18n@12.4.3':
-    resolution: {integrity: sha512-ECdz96IEk04rOZLMZSXTa6+6z+fgaIk9oHoyZC68Wzq1pkfQajdi7bnDCZ3Zsz5ikq1gEqIJpLgdL69Nd9lmdg==}
-    peerDependencies:
-      react: '>=18'
-
   '@grafana/plugin-e2e@3.5.1':
     resolution: {integrity: sha512-iYId7j9Vg0P5t2ciHTsu0Rp7S268qdjdIWhkP42AMTo/M3JhC4UWKzYOodvjekmWr+9TNOGph7FLmzcf26WWNA==}
     engines: {node: '>=20 <=24'}
@@ -725,9 +695,6 @@ packages:
 
   '@grafana/schema@12.4.2':
     resolution: {integrity: sha512-dkIEvcqTMitGO1qQcg4Hd2RoLK/YcQCNZQusX4sINvWH64u3uryBn3TS6TTPItvkiccWULYuZSWcQMV478i9Yg==}
-
-  '@grafana/schema@12.4.3':
-    resolution: {integrity: sha512-fFoYfBcCTDWliz37JsKf8GwqF5Ju64UJk9DsDBN0T5S7LJoKiIOEe5Gl3vJsmNgcYJhyKRedX/2RPYy+Cyo4LQ==}
 
   '@grafana/tsconfig@2.0.1':
     resolution: {integrity: sha512-yGNQWQDlxFfklzMfk0i8qnDqKOvIGc0Aqe62zLS4LTqptkhnyLEVsdaVmX99m3QFOcBiiFn8scREDzGeF2iNvQ==}
@@ -5855,8 +5822,6 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/runtime@7.27.1': {}
-
   '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
@@ -6030,18 +5995,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@floating-ui/core@1.6.9':
-    dependencies:
-      '@floating-ui/utils': 0.2.9
-
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
-
-  '@floating-ui/dom@1.6.13':
-    dependencies:
-      '@floating-ui/core': 1.6.9
-      '@floating-ui/utils': 0.2.9
 
   '@floating-ui/dom@1.7.6':
     dependencies:
@@ -6063,8 +6019,6 @@ snapshots:
       tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.11': {}
-
-  '@floating-ui/utils@0.2.9': {}
 
   '@formatjs/ecma402-abstract@2.3.3':
     dependencies:
@@ -6152,52 +6106,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@grafana/data@12.4.3(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
-    dependencies:
-      '@braintree/sanitize-url': 7.0.1
-      '@grafana/i18n': 12.4.3(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@grafana/schema': 12.4.3
-      '@leeoniya/ufuzzy': 1.0.19
-      '@types/d3-interpolate': 3.0.4
-      '@types/string-hash': 1.1.3
-      '@types/systemjs': 6.15.3
-      d3-interpolate: 3.0.1
-      d3-scale-chromatic: 3.1.0
-      date-fns: 4.1.0
-      dompurify: 3.3.0
-      eventemitter3: 5.0.1
-      fast_array_intersect: 1.1.0
-      history: 4.10.1
-      lodash: 4.18.1
-      marked: 16.3.0
-      marked-mangle: 1.1.12(marked@16.3.0)
-      moment: 2.30.1
-      moment-timezone: 0.5.47
-      ol: 10.7.0
-      papaparse: 5.5.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      rxjs: 7.8.2
-      string-hash: 1.1.3
-      tinycolor2: 1.6.0
-      tslib: 2.8.1
-      uplot: 1.6.32
-      xss: 1.0.15
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - eslint
-      - react-native
-      - supports-color
-      - typescript
-
   '@grafana/e2e-selectors@12.4.2':
-    dependencies:
-      semver: 7.7.4
-      tslib: 2.8.1
-      typescript: 5.9.2
-
-  '@grafana/e2e-selectors@12.4.3':
     dependencies:
       semver: 7.7.4
       tslib: 2.8.1
@@ -6233,24 +6142,6 @@ snapshots:
       web-vitals: 4.2.4
 
   '@grafana/i18n@12.4.2(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
-    dependencies:
-      '@formatjs/intl-durationformat': 0.7.6
-      '@typescript-eslint/utils': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
-      fast-deep-equal: 3.1.3
-      i18next: 25.10.10(typescript@5.8.3)
-      i18next-browser-languagedetector: 8.2.1
-      i18next-pseudo: 2.2.1
-      micro-memoize: 4.1.3
-      react: 18.3.1
-      react-i18next: 15.7.4(i18next@25.10.10(typescript@5.8.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - eslint
-      - react-dom
-      - react-native
-      - supports-color
-      - typescript
-
-  '@grafana/i18n@12.4.3(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       '@formatjs/intl-durationformat': 0.7.6
       '@typescript-eslint/utils': 8.58.2(eslint@9.39.4)(typescript@5.8.3)
@@ -6314,10 +6205,6 @@ snapshots:
       - typescript
 
   '@grafana/schema@12.4.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@grafana/schema@12.4.3':
     dependencies:
       tslib: 2.8.1
 
@@ -7002,7 +6889,7 @@ snapshots:
   '@react-aria/dialog@3.5.31(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/interactions': 3.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@react-aria/overlays': 3.30.0(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/overlays': 3.32.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-aria/utils': 3.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/dialog': 3.6.0(@react-spectrum/provider@3.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-types/shared': 3.34.0(react@18.3.1)
@@ -8657,7 +8544,7 @@ snapshots:
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.29.2
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   domexception@4.0.0:
     dependencies:
@@ -9306,7 +9193,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -9354,7 +9241,7 @@ snapshots:
 
   i18next-browser-languagedetector@8.2.1:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
 
   i18next-pseudo@2.2.1:
     dependencies:
@@ -9362,7 +9249,7 @@ snapshots:
 
   i18next@19.9.2:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
 
   i18next@25.10.10(typescript@5.8.3):
     dependencies:
@@ -10525,9 +10412,9 @@ snapshots:
 
   nano-css@5.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       css-tree: 1.1.3
-      csstype: 3.1.3
+      csstype: 3.2.3
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 7.0.1
       react: 18.3.1
@@ -11085,7 +10972,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      '@floating-ui/dom': 1.6.13
+      '@floating-ui/dom': 1.7.6
       '@types/react-transition-group': 4.4.12(@types/react@18.3.28)
       memoize-one: 6.0.0
       prop-types: 15.8.1
@@ -11262,7 +11149,7 @@ snapshots:
 
   rtl-css-js@1.16.1:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
 
   run-async@2.4.1: {}
 


### PR DESCRIPTION
## Summary

Replaces the caret-range + `pnpm.overrides` workaround with direct exact pins on every `@grafana/*` dependency.

| Package | From | To |
|---|---|---|
| `@grafana/data` | `^12.2.0` | `12.4.2` |
| `@grafana/i18n` | `^12.2.0` | `12.4.2` |
| `@grafana/runtime` | `^12.2.0` | `12.4.2` |
| `@grafana/schema` | `^12.2.0` | `12.4.2` |
| `@grafana/ui` | `^12.2.0` | `12.4.2` |
| `@grafana/e2e-selectors` (dev) | `^12.4.3` | `12.4.2` |
| `pnpm.overrides.@grafana/runtime` | `"12.4.2"` | removed |

## Why

`@grafana/runtime@12.4.3` declares a hard peer dependency on `@grafana/ui@12.4.3` that was never published to npm. The previous setup worked around this with a `pnpm.overrides` entry forcing runtime to 12.4.2, while the other `@grafana/*` caret ranges floated freely. Exact pins collapse every resolution to 12.4.2 and make the override unnecessary.

Renovate already guards against `@grafana/*@13.x` via the `allowedVersions: "<13.0.0"` rule in `renovate.json`, and will surface 12.4.4+ as individual PRs once upstream publishes one with a matching `@grafana/ui`.

## Incidental lockfile correction

The existing lockfile had `glob@10.4.5` while `package.json` declared `^12.0.0` — a pre-existing drift. `pnpm install` now resolves glob to 12.0.0 to match the declared range.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:ci` — 227/227 pass
- [x] `pnpm lint` — 0 errors (9 pre-existing deprecation warnings)
- [x] `pnpm build` — succeeds
- [ ] E2E matrix green across all four Grafana 11.x/12.x versions in CI