### PR TITLE
fix(ci): pnpm restore-keys + group Renovate security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,16 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
@@ -194,8 +202,16 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: pnpm-lock.yaml
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
 
       - name: Install dev dependencies
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "enabled": true,
+    "groupName": "security",
     "labels": ["dependencies", "security"],
     "prPriority": 10,
     "schedule": ["at any time"],


### PR DESCRIPTION
## Problems

**CI cache accumulation:** `actions/setup-node` with `cache: 'pnpm'` does not support `restore-keys`. Every `pnpm-lock.yaml` change creates a fresh ~130MB cache entry with no fallback, causing caches to accumulate.

**Renovate security PRs:** Without `groupName`, each CVE triggers its own immediate PR — one lockfile change and one CI run per vulnerability. With 35 open vulnerabilities on this repo, this is significant.

## Fixes

**`.github/workflows/ci.yml`** (both `build` and `playwright-tests` jobs): replace built-in `cache: 'pnpm'` with explicit `actions/cache` + `restore-keys` so a lockfile change restores the previous cache rather than starting cold.

**`renovate.json`**: add `"groupName": "security"` to `vulnerabilityAlerts` so all CVE fixes are batched into one PR.