### PR TITLE
ci: pin grafana/plugin-actions to commit SHAs

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: grafana/plugin-actions/bundle-size@bundle-size/v1.0.2
+      - uses: grafana/plugin-actions/bundle-size@6b3176d6bd4b6885b6433410aeb42de2f76d8a09 # bundle-size/v1.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           persist-credentials: false
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@e2e-version/v1.1.2
+        uses: grafana/plugin-actions/e2e-version@698612a13f3253e7dcd5b3c66823acc73321a5ed # e2e-version/v1.1.2
         with:
           version-resolver-type: plugin-grafana-dependency
           limit: "4"
@@ -224,7 +224,7 @@ jobs:
           ANONYMOUS_AUTH_ENABLED=false DEVELOPMENT=false GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for grafana server
-        uses: grafana/plugin-actions/wait-for-grafana@wait-for-grafana/v1.0.2
+        uses: grafana/plugin-actions/wait-for-grafana@c8ad89b7d81f8cb9967bb65e444d85f5b3d7c674 # wait-for-grafana/v1.0.2
         with:
           url: http://localhost:3000/login
 
@@ -233,7 +233,7 @@ jobs:
         run: pnpm run playwright:test
 
       - name: Upload e2e test summary
-        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@upload-report-artifacts/v1.0.1
+        uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@fa3356df288e68f5e900ab466e98b0bf9bad3118 # upload-report-artifacts/v1.0.1
         if: ${{ always() && !cancelled() }}
         with:
           upload-report: true
@@ -275,6 +275,6 @@ jobs:
           # fetch with `Duplicate header: Authorization` / HTTP 400.
           persist-credentials: false
       - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@deploy-report-pages/v1.1.0
+        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@5da62466881cdba091672353cf3c72ca348d01b1 # deploy-report-pages/v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -22,7 +22,7 @@ jobs:
     # above only apply if you switch `token` back to secrets.GITHUB_TOKEN.
     permissions: {}
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.1
+      - uses: grafana/plugin-actions/create-plugin-update@244c3bc9c6eb94bc1dd6458ade2462499bbf0f5b # create-plugin-update/v2.0.1
         with:
           # Fine-grained personal access token saved in repo secrets as `GH_PAT_TOKEN`.
           # See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -41,7 +41,7 @@ jobs:
           echo "modulets=${MODULETS}" >> "$GITHUB_OUTPUT"
 
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@is-compatible/v1.0.2
+        uses: grafana/plugin-actions/is-compatible@a8d2790586995c0112186302a0ebee61f02510a7 # is-compatible/v1.0.2
         with:
           module: ${{ steps.find-module-ts.outputs.modulets }}
           comment-pr: "no"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: grafana/plugin-actions/build-plugin@build-plugin/v1.0.2
+      - uses: grafana/plugin-actions/build-plugin@62c2d322b176c9b104fae6b300029e08d0a0ee8e # build-plugin/v1.0.2
         with:
           # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
           # save the value in your repository secrets


### PR DESCRIPTION
### CI/CD

Pin all `grafana/plugin-actions` references to immutable commit SHAs for supply chain security (zizmor compliance).

| Action | Tag | SHA |
|---|---|---|
| bundle-size | bundle-size/v1.0.2 | 6b3176d6 |
| e2e-version | e2e-version/v1.1.2 | 698612a1 |
| wait-for-grafana | wait-for-grafana/v1.0.2 | c8ad89b7 |
| upload-report-artifacts | upload-report-artifacts/v1.0.1 | fa3356df |
| deploy-report-pages | deploy-report-pages/v1.1.0 | 5da62466 |
| create-plugin-update | create-plugin-update/v2.0.1 | 244c3bc9 |
| is-compatible | is-compatible/v1.0.2 | a8d279058 |
| build-plugin | build-plugin/v1.0.2 | 62c2d322 |

Files changed: `bundle-stats.yml`, `ci.yml`, `cp-update.yml`, `is-compatible.yml`, `release.yml`

## Test plan

- [ ] Verify CI passes on this branch
- [ ] Confirm no workflow uses unpinned action refs