### PR TITLE
ci: update grafana/plugin-actions to latest versions

### DIFF
--- a/.github/workflows/bundle-stats.yml
+++ b/.github/workflows/bundle-stats.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: grafana/plugin-actions/bundle-size@6b3176d6bd4b6885b6433410aeb42de2f76d8a09 # bundle-size/v1.0.2
+      - uses: grafana/plugin-actions/bundle-size@a66a1c96cdbb176f9cccf10cf23593e250db7cce # bundle-size/v1.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           persist-credentials: false
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@698612a13f3253e7dcd5b3c66823acc73321a5ed # e2e-version/v1.1.2
+        uses: grafana/plugin-actions/e2e-version@73cd57e848b81e75e3c17697e6701c9fa1404bcc # e2e-version/v2.0.0
         with:
           version-resolver-type: plugin-grafana-dependency
           limit: "4"
@@ -224,7 +224,7 @@ jobs:
           ANONYMOUS_AUTH_ENABLED=false DEVELOPMENT=false GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for grafana server
-        uses: grafana/plugin-actions/wait-for-grafana@c8ad89b7d81f8cb9967bb65e444d85f5b3d7c674 # wait-for-grafana/v1.0.2
+        uses: grafana/plugin-actions/wait-for-grafana@016148f3c2f244edb17da23f0d9aa0661b6dbf6f # wait-for-grafana/v1.0.3
         with:
           url: http://localhost:3000/login
 

--- a/.github/workflows/cp-update.yml
+++ b/.github/workflows/cp-update.yml
@@ -22,7 +22,7 @@ jobs:
     # above only apply if you switch `token` back to secrets.GITHUB_TOKEN.
     permissions: {}
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@244c3bc9c6eb94bc1dd6458ade2462499bbf0f5b # create-plugin-update/v2.0.1
+      - uses: grafana/plugin-actions/create-plugin-update@b82357e85d512c678416146ca4e9f8672bd108da # create-plugin-update/v2.0.2
         with:
           # Fine-grained personal access token saved in repo secrets as `GH_PAT_TOKEN`.
           # See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -41,7 +41,7 @@ jobs:
           echo "modulets=${MODULETS}" >> "$GITHUB_OUTPUT"
 
       - name: Compatibility check
-        uses: grafana/plugin-actions/is-compatible@a8d2790586995c0112186302a0ebee61f02510a7 # is-compatible/v1.0.2
+        uses: grafana/plugin-actions/is-compatible@4698961fa64137fcac207108397ebe8a738a33d1 # is-compatible/v1.0.3
         with:
           module: ${{ steps.find-module-ts.outputs.modulets }}
           comment-pr: "no"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: grafana/plugin-actions/build-plugin@62c2d322b176c9b104fae6b300029e08d0a0ee8e # build-plugin/v1.0.2
+      - uses: grafana/plugin-actions/build-plugin@8b12a2d6fa5fc0939a6bf75905453d4b505ef29a # build-plugin/v1.2.0
         with:
           # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
           # save the value in your repository secrets


### PR DESCRIPTION
### CI/CD

Update all `grafana/plugin-actions` to latest versions, pinned to commit SHAs.

| Action | Old | New |
|---|---|---|
| bundle-size | v1.0.2 | v1.1.0 |
| e2e-version | v1.1.2 | **v2.0.0** |
| wait-for-grafana | v1.0.2 | v1.0.3 |
| create-plugin-update | v2.0.1 | v2.0.2 |
| is-compatible | v1.0.2 | v1.0.3 |
| build-plugin | v1.0.2 | v1.2.0 |

Files changed: `bundle-stats.yml`, `ci.yml`, `cp-update.yml`, `is-compatible.yml`, `release.yml`

## Test plan

- [ ] Verify CI passes with updated actions
- [ ] Check e2e tests pass (e2e-version is a major bump v1→v2)