### PR TITLE
chore: bump create-plugin 7.1.7→7.6.0 and node 24.14.1→24.15.0

### DIFF
--- a/.config/.cprc.json
+++ b/.config/.cprc.json
@@ -1,4 +1,4 @@
 {
-  "version": "7.1.7",
+  "version": "7.6.0",
   "features": {}
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-node = { version = "24.14.1", postinstall = "corepack enable" }
+node = { version = "24.15.0", postinstall = "corepack enable" }


### PR DESCRIPTION
## Summary

- Bump `@grafana/create-plugin` scaffolding version `7.1.7` → `7.6.0` in `.config/.cprc.json`
- Bump Node.js `24.14.1` → `24.15.0` in `mise.toml`

## Test plan

- [x] `pnpm install` — clean, no errors