### PR TITLE
feat: regression-check scripts to compare e2e results against released plugin

### DIFF
--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -1,0 +1,116 @@
+name: Regression Check
+
+# Run on PRs to main to catch any test that passed on the released plugin
+# but now fails on the PR's dev build — a genuine regression.
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: regression-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  regression-check:
+    name: Baseline regression check (v2.0.2 vs dev)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: []   # independent — no need to wait for the main build job
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build plugin
+        run: pnpm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # -----------------------------------------------------------------------
+      # Dev container (port 3000): current PR build, Grafana 13.0.2
+      # -----------------------------------------------------------------------
+      - name: Start dev container (current build)
+        run: |
+          docker compose pull
+          ANONYMOUS_AUTH_ENABLED=false DEVELOPMENT=false \
+            GRAFANA_VERSION=13.0.2 GRAFANA_IMAGE=grafana-oss \
+            docker compose up -d
+
+      - name: Wait for dev Grafana
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/api/health | grep -q '"database": "ok"'; then
+              echo "Dev Grafana ready after ${i}s"
+              break
+            fi
+            sleep 2
+          done
+
+      # -----------------------------------------------------------------------
+      # Released container (port 3001): v2.0.2 from GitHub releases
+      # -----------------------------------------------------------------------
+      - name: Start released container (v2.0.2)
+        run: docker compose -f docker-compose.released.yml up -d
+
+      - name: Wait for released Grafana
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3001/api/health | grep -q '"database": "ok"'; then
+              echo "Released Grafana ready after ${i}s"
+              break
+            fi
+            sleep 2
+          done
+
+      # -----------------------------------------------------------------------
+      # Run baseline regression check
+      # CI=true skips the progress (list reporter) pass — only JSON capture runs.
+      # Script exits 1 if any baseline test that passed on v2.0.2 fails on dev.
+      # -----------------------------------------------------------------------
+      - name: Run baseline regression check
+        id: regression
+        env:
+          CI: "true"
+        run: ./scripts/baseline-regression-check.sh
+
+      - name: Upload regression results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: regression-results-${{ github.run_id }}
+          path: /tmp/pw-baseline-regression/
+          retention-days: 7
+
+      - name: Stop containers
+        if: always()
+        run: |
+          docker compose down || true
+          docker compose -f docker-compose.released.yml down || true

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -1,21 +1,22 @@
 name: Regression Check
 
-# Run on PRs to main to catch any test that passed on the released plugin
-# but now fails on the PR's dev build — a genuine regression.
+# Manual trigger only — run when you're ready to verify before merging.
+# Usage:
+#   gh workflow run regression-check.yml --ref <branch>
+#   Or: GitHub Actions UI → "Run workflow"
 on:
-  pull_request:
-    branches:
-      - main
-
-concurrency:
-  group: regression-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_dispatch:
+    inputs:
+      released_version:
+        description: 'Released plugin version to compare against'
+        required: false
+        default: 'v2.0.2'
 
 permissions: {}
 
 jobs:
   regression-check:
-    name: Baseline regression check (v2.0.2 vs dev)
+    name: Baseline regression check (${{ inputs.released_version }} vs dev)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -44,6 +45,12 @@ jobs:
           key: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: node-cache-${{ runner.os }}-${{ runner.arch }}-pnpm-
 
+      - name: Cache released plugin ZIP
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: /tmp/plugin-release-cache
+          key: plugin-release-${{ inputs.released_version }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
@@ -54,50 +61,56 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       # -----------------------------------------------------------------------
-      # Dev container (port 3000): current PR build, Grafana 13.0.2
+      # Start both containers simultaneously — they can pull/init in parallel.
+      # Dev on port 3000, released on port 3001.
       # -----------------------------------------------------------------------
-      - name: Start dev container (current build)
+      - name: Start dev and released containers
+        env:
+          RELEASED_VERSION: ${{ inputs.released_version }}
         run: |
-          docker compose pull
+          # Strip leading 'v' for the ZIP filename (v2.0.2 → 2.0.2)
+          VER="${RELEASED_VERSION#v}"
+          ZIP_URL="https://github.com/briangann/grafana-datatable-panel/releases/download/${RELEASED_VERSION}/briangann-datatable-panel-${VER}.zip"
+
+          # Use cached ZIP if available, otherwise let Grafana download it
+          mkdir -p /tmp/plugin-release-cache
+          if [ ! -f "/tmp/plugin-release-cache/plugin-${VER}.zip" ]; then
+            curl -sL "$ZIP_URL" -o "/tmp/plugin-release-cache/plugin-${VER}.zip"
+          fi
+
+          # Dev container
           ANONYMOUS_AUTH_ENABLED=false DEVELOPMENT=false \
             GRAFANA_VERSION=13.0.2 GRAFANA_IMAGE=grafana-oss \
-            docker compose up -d
+            docker compose up -d &
 
-      - name: Wait for dev Grafana
+          # Released container — override GF_INSTALL_PLUGINS to use local ZIP
+          GF_INSTALL_PLUGINS="file:///tmp/plugin-release-cache/plugin-${VER}.zip;briangann-datatable-panel" \
+            docker compose -f docker-compose.released.yml up -d &
+
+          wait
+          echo "Both containers started"
+
+      - name: Wait for both containers
         run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000/api/health | grep -q '"database": "ok"'; then
-              echo "Dev Grafana ready after ${i}s"
-              break
-            fi
-            sleep 2
+          for port in 3000 3001; do
+            for i in $(seq 1 30); do
+              if curl -sf "http://localhost:${port}/api/health" 2>/dev/null | grep -q '"database": "ok"'; then
+                echo "Port ${port} ready after ${i}s"
+                break
+              fi
+              sleep 2
+            done
           done
 
       # -----------------------------------------------------------------------
-      # Released container (port 3001): v2.0.2 from GitHub releases
-      # -----------------------------------------------------------------------
-      - name: Start released container (v2.0.2)
-        run: docker compose -f docker-compose.released.yml up -d
-
-      - name: Wait for released Grafana
-        run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3001/api/health | grep -q '"database": "ok"'; then
-              echo "Released Grafana ready after ${i}s"
-              break
-            fi
-            sleep 2
-          done
-
-      # -----------------------------------------------------------------------
-      # Run baseline regression check
-      # CI=true skips the progress (list reporter) pass — only JSON capture runs.
-      # Script exits 1 if any baseline test that passed on v2.0.2 fails on dev.
+      # Playwright auth must run sequentially (shared auth file).
+      # After auth, run JSON captures in parallel against both containers.
       # -----------------------------------------------------------------------
       - name: Run baseline regression check
         id: regression
         env:
           CI: "true"
+          RELEASED_VERSION: ${{ inputs.released_version }}
         run: ./scripts/baseline-regression-check.sh
 
       - name: Upload regression results

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       released_version:
-        description: 'Released plugin version to compare against'
+        description: 'Pin a specific released version (e.g. v2.0.2). Leave blank to use the latest version from the Grafana catalog.'
         required: false
-        default: 'v2.0.2'
+        default: ''
 
 # Cancel a previous run for the same ref if a new one is triggered.
 concurrency:
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   regression-check:
-    name: Baseline regression check (${{ inputs.released_version }} vs dev)
+    name: Baseline regression check (${{ inputs.released_version || 'latest catalog' }} vs dev)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -73,15 +73,20 @@ jobs:
         env:
           RELEASED_VERSION: ${{ inputs.released_version }}
         run: |
-          # Strip leading 'v' for the ZIP filename (v2.0.2 → 2.0.2)
-          VER="${RELEASED_VERSION#v}"
-          ZIP_URL="https://github.com/briangann/grafana-datatable-panel/releases/download/${RELEASED_VERSION}/briangann-datatable-panel-${VER}.zip"
-
-          # Use cached ZIP if available, otherwise let Grafana download it
           mkdir -p /tmp/plugin-release-cache
-          if [ ! -f "/tmp/plugin-release-cache/plugin-${VER}.zip" ]; then
-            # -sSfL: silent, show errors, fail on HTTP errors, follow redirects
-            curl -sSfL "$ZIP_URL" -o "/tmp/plugin-release-cache/plugin-${VER}.zip"
+
+          # If a specific version was requested, cache its ZIP and use that.
+          # Otherwise leave GF_PLUGINS_PREINSTALL_DATATABLE unset — the released
+          # container will install the latest version from the Grafana catalog.
+          DATATABLE_OVERRIDE=""
+          if [ -n "$RELEASED_VERSION" ]; then
+            VER="${RELEASED_VERSION#v}"
+            ZIP_URL="https://github.com/briangann/grafana-datatable-panel/releases/download/${RELEASED_VERSION}/briangann-datatable-panel-${VER}.zip"
+            if [ ! -f "/tmp/plugin-release-cache/plugin-${VER}.zip" ]; then
+              # -sSfL: silent, show errors, fail on HTTP errors, follow redirects
+              curl -sSfL "$ZIP_URL" -o "/tmp/plugin-release-cache/plugin-${VER}.zip"
+            fi
+            DATATABLE_OVERRIDE="file:///var/lib/grafana/plugin-cache/plugin-${VER}.zip;briangann-datatable-panel"
           fi
 
           # Dev container
@@ -89,11 +94,9 @@ jobs:
             GRAFANA_VERSION=13.0.2 GRAFANA_IMAGE=grafana-oss \
             docker compose up -d &
 
-          # Released container — use container-side path to the cached ZIP.
-          # /tmp/plugin-release-cache is mounted into the container at
-          # /var/lib/grafana/plugin-cache (see docker-compose.released.yml).
-          # GF_PLUGINS_PREINSTALL_DATATABLE overrides the default remote URL.
-          GF_PLUGINS_PREINSTALL_DATATABLE="file:///var/lib/grafana/plugin-cache/plugin-${VER}.zip;briangann-datatable-panel" \
+          # Released container — uses latest from Grafana catalog unless
+          # DATATABLE_OVERRIDE is set (pinned version via workflow input).
+          GF_PLUGINS_PREINSTALL_DATATABLE="$DATATABLE_OVERRIDE" \
             docker compose -f docker-compose.released.yml up -d &
 
           wait

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -92,7 +92,8 @@ jobs:
           # Released container — use container-side path to the cached ZIP.
           # /tmp/plugin-release-cache is mounted into the container at
           # /var/lib/grafana/plugin-cache (see docker-compose.released.yml).
-          GF_INSTALL_PLUGINS="file:///var/lib/grafana/plugin-cache/plugin-${VER}.zip;briangann-datatable-panel" \
+          # GF_PLUGINS_PREINSTALL_DATATABLE overrides the default remote URL.
+          GF_PLUGINS_PREINSTALL_DATATABLE="file:///var/lib/grafana/plugin-cache/plugin-${VER}.zip;briangann-datatable-panel" \
             docker compose -f docker-compose.released.yml up -d &
 
           wait

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -18,7 +18,6 @@ jobs:
     name: Baseline regression check (v2.0.2 vs dev)
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: []   # independent — no need to wait for the main build job
     permissions:
       contents: read
 

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: 'v2.0.2'
 
+# Cancel a previous run for the same ref if a new one is triggered.
+concurrency:
+  group: regression-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -75,7 +80,8 @@ jobs:
           # Use cached ZIP if available, otherwise let Grafana download it
           mkdir -p /tmp/plugin-release-cache
           if [ ! -f "/tmp/plugin-release-cache/plugin-${VER}.zip" ]; then
-            curl -sL "$ZIP_URL" -o "/tmp/plugin-release-cache/plugin-${VER}.zip"
+            # -sSfL: silent, show errors, fail on HTTP errors, follow redirects
+            curl -sSfL "$ZIP_URL" -o "/tmp/plugin-release-cache/plugin-${VER}.zip"
           fi
 
           # Dev container
@@ -83,8 +89,10 @@ jobs:
             GRAFANA_VERSION=13.0.2 GRAFANA_IMAGE=grafana-oss \
             docker compose up -d &
 
-          # Released container — override GF_INSTALL_PLUGINS to use local ZIP
-          GF_INSTALL_PLUGINS="file:///tmp/plugin-release-cache/plugin-${VER}.zip;briangann-datatable-panel" \
+          # Released container — use container-side path to the cached ZIP.
+          # /tmp/plugin-release-cache is mounted into the container at
+          # /var/lib/grafana/plugin-cache (see docker-compose.released.yml).
+          GF_INSTALL_PLUGINS="file:///var/lib/grafana/plugin-cache/plugin-${VER}.zip;briangann-datatable-panel" \
             docker compose -f docker-compose.released.yml up -d &
 
           wait

--- a/docker-compose.released.yml
+++ b/docker-compose.released.yml
@@ -1,0 +1,28 @@
+# Runs the latest RELEASED plugin (v2.0.2) on port 3001 for regression comparison.
+# Usage: docker compose -f docker-compose.released.yml up -d
+#
+# The released plugin is installed from the GitHub release ZIP so no local
+# build is required. Use the same provisioned dashboards as the dev container
+# so the same e2e tests can run against both.
+services:
+  grafana-released:
+    platform: 'linux/amd64'
+    image: grafana/grafana-oss:13.0.2
+    container_name: briangann-datatable-panel-released
+    user: root
+    ports:
+      - "3001:3000/tcp"
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning
+    environment:
+      - TERM=linux
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=false
+      - GF_FEATURE_TOGGLES_ENABLE=nestedFolders
+      - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=briangann-datatable-panel
+      # Install released plugin from GitHub release ZIP
+      - GF_INSTALL_PLUGINS=https://github.com/briangann/grafana-datatable-panel/releases/download/v2.0.2/briangann-datatable-panel-2.0.2.zip;briangann-datatable-panel
+      # Infinity datasource required by example dashboards
+      - GF_PLUGINS_PREINSTALL=yesoreyeram-infinity-datasource
+      - GF_LOG_LEVEL=warn

--- a/docker-compose.released.yml
+++ b/docker-compose.released.yml
@@ -14,7 +14,7 @@ services:
       - "3001:3000/tcp"
     volumes:
       - ./provisioning:/etc/grafana/provisioning
-      # Mount the host plugin cache dir so GF_INSTALL_PLUGINS can use file:// paths.
+      # Mount the host plugin cache dir so GF_PLUGINS_PREINSTALL can use file:// paths.
       # The directory is created by the workflow before docker compose up.
       - /tmp/plugin-release-cache:/var/lib/grafana/plugin-cache:ro
     environment:
@@ -24,10 +24,9 @@ services:
       - GF_AUTH_DISABLE_LOGIN_FORM=false
       - GF_FEATURE_TOGGLES_ENABLE=nestedFolders
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=briangann-datatable-panel
-      # Install released plugin — override with GF_INSTALL_PLUGINS env var to use
-      # a local cached ZIP in CI (avoids re-downloading on every run).
+      # Install released plugin — override with GF_PLUGINS_PREINSTALL_DATATABLE env var
+      # to use a local cached ZIP in CI (avoids re-downloading on every run).
       # Default: fetch directly from GitHub releases.
-      - GF_INSTALL_PLUGINS=${GF_INSTALL_PLUGINS:-https://github.com/briangann/grafana-datatable-panel/releases/download/v2.0.2/briangann-datatable-panel-2.0.2.zip;briangann-datatable-panel}
-      # Infinity datasource required by example dashboards
-      - GF_PLUGINS_PREINSTALL=yesoreyeram-infinity-datasource
+      # GF_PLUGINS_PREINSTALL replaces the deprecated GF_INSTALL_PLUGINS (Grafana 10+).
+      - GF_PLUGINS_PREINSTALL=${GF_PLUGINS_PREINSTALL_DATATABLE:-https://github.com/briangann/grafana-datatable-panel/releases/download/v2.0.2/briangann-datatable-panel-2.0.2.zip;briangann-datatable-panel},yesoreyeram-infinity-datasource
       - GF_LOG_LEVEL=warn

--- a/docker-compose.released.yml
+++ b/docker-compose.released.yml
@@ -21,8 +21,10 @@ services:
       - GF_AUTH_DISABLE_LOGIN_FORM=false
       - GF_FEATURE_TOGGLES_ENABLE=nestedFolders
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=briangann-datatable-panel
-      # Install released plugin from GitHub release ZIP
-      - GF_INSTALL_PLUGINS=https://github.com/briangann/grafana-datatable-panel/releases/download/v2.0.2/briangann-datatable-panel-2.0.2.zip;briangann-datatable-panel
+      # Install released plugin — override with GF_INSTALL_PLUGINS env var to use
+      # a local cached ZIP in CI (avoids re-downloading on every run).
+      # Default: fetch directly from GitHub releases.
+      - GF_INSTALL_PLUGINS=${GF_INSTALL_PLUGINS:-https://github.com/briangann/grafana-datatable-panel/releases/download/v2.0.2/briangann-datatable-panel-2.0.2.zip;briangann-datatable-panel}
       # Infinity datasource required by example dashboards
       - GF_PLUGINS_PREINSTALL=yesoreyeram-infinity-datasource
       - GF_LOG_LEVEL=warn

--- a/docker-compose.released.yml
+++ b/docker-compose.released.yml
@@ -1,4 +1,4 @@
-# Runs the latest RELEASED plugin (v2.0.2) on port 3001 for regression comparison.
+# Runs the latest RELEASED plugin (from the Grafana catalog) on port 3001 for regression comparison.
 # Usage: docker compose -f docker-compose.released.yml up -d
 #
 # The released plugin is installed from the GitHub release ZIP so no local
@@ -24,9 +24,9 @@ services:
       - GF_AUTH_DISABLE_LOGIN_FORM=false
       - GF_FEATURE_TOGGLES_ENABLE=nestedFolders
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=briangann-datatable-panel
-      # Install released plugin — override with GF_PLUGINS_PREINSTALL_DATATABLE env var
-      # to use a local cached ZIP in CI (avoids re-downloading on every run).
-      # Default: fetch directly from GitHub releases.
-      # GF_PLUGINS_PREINSTALL replaces the deprecated GF_INSTALL_PLUGINS (Grafana 10+).
-      - GF_PLUGINS_PREINSTALL=${GF_PLUGINS_PREINSTALL_DATATABLE:-https://github.com/briangann/grafana-datatable-panel/releases/download/v2.0.2/briangann-datatable-panel-2.0.2.zip;briangann-datatable-panel},yesoreyeram-infinity-datasource
+      # Install released plugin from the Grafana catalog (latest published version).
+      # Override GF_PLUGINS_PREINSTALL_DATATABLE to pin a specific version or use
+      # a local cached ZIP in CI (e.g. file:///var/lib/grafana/plugin-cache/plugin.zip;id).
+      # Falls back to GitHub releases URL if set explicitly via the override.
+      - GF_PLUGINS_PREINSTALL=${GF_PLUGINS_PREINSTALL_DATATABLE:-briangann-datatable-panel},yesoreyeram-infinity-datasource
       - GF_LOG_LEVEL=warn

--- a/docker-compose.released.yml
+++ b/docker-compose.released.yml
@@ -14,6 +14,9 @@ services:
       - "3001:3000/tcp"
     volumes:
       - ./provisioning:/etc/grafana/provisioning
+      # Mount the host plugin cache dir so GF_INSTALL_PLUGINS can use file:// paths.
+      # The directory is created by the workflow before docker compose up.
+      - /tmp/plugin-release-cache:/var/lib/grafana/plugin-cache:ro
     environment:
       - TERM=linux
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/scripts/baseline-regression-check.sh
+++ b/scripts/baseline-regression-check.sh
@@ -67,7 +67,10 @@ echo "▶ Running BASELINE tests against RELEASED plugin (v2.0.2)..."
 echo "  (${#BASELINE_TESTS[@]} test files — features that existed before our changes)"
 echo ""
 cd "$REPO_DIR"
-GRAFANA_URL="$RELEASED_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=list || true
+# In CI skip the progress pass (no TTY, saves time); locally show live output.
+if [[ "${CI:-}" != "true" ]]; then
+  GRAFANA_URL="$RELEASED_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=list || true
+fi
 GRAFANA_URL="$RELEASED_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=json > "$RELEASED_JSON" 2>/dev/null || true
 echo "  JSON → $RELEASED_JSON"
 
@@ -77,7 +80,9 @@ echo "  JSON → $RELEASED_JSON"
 echo ""
 echo "▶ Running BASELINE tests against DEV build..."
 echo ""
-GRAFANA_URL="$DEV_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=list || true
+if [[ "${CI:-}" != "true" ]]; then
+  GRAFANA_URL="$DEV_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=list || true
+fi
 GRAFANA_URL="$DEV_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=json > "$DEV_JSON" 2>/dev/null || true
 echo "  JSON → $DEV_JSON"
 
@@ -145,6 +150,7 @@ if regressions:
     for t, status in regressions:
         p(f"   • [{status}] {t}")
     p("\n   ↑ These are genuine bugs introduced by our changes.")
+    sys.exit(1)
 else:
     p("\n✅ No regressions in baseline tests")
     p("   Every baseline test that passed on v2.0.2 also passes on dev")

--- a/scripts/baseline-regression-check.sh
+++ b/scripts/baseline-regression-check.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# baseline-regression-check.sh — genuine regression check.
+#
+# Runs ONLY the test files that existed before our changes (the stable
+# baseline) against both the released plugin and the dev build. Any test
+# that passed on the released plugin but now fails on dev is a true
+# regression introduced by our code.
+#
+# New test files (row-coloring, row-column-coloring) are explicitly excluded
+# because those test features that didn't exist in the released plugin —
+# running them here would only produce noise.
+#
+# Usage: ./scripts/baseline-regression-check.sh
+#
+# Requires: docker running, dev container already on port 3000
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Test files that existed before PR #329 and were not modified by it.
+# These form the stable baseline: if they pass on released they must pass on dev.
+BASELINE_TESTS=(
+  tests/panel/clickthrough-urls.spec.ts
+  tests/panel/column-filter.spec.ts
+  tests/panel/column-styles.spec.ts
+  tests/panel/paging.spec.ts
+  tests/panel/rendering.spec.ts
+  tests/panel/row-numbers.spec.ts
+  tests/panel/sorting.spec.ts
+  tests/panel/text-alignment.spec.ts
+  tests/panel/thresholds.spec.ts
+  tests/setup/grafana-version.spec.ts
+  tests/setup/plugin-installed.spec.ts
+  tests/setup/ui-setup.spec.ts
+)
+
+RELEASED_URL="http://localhost:3001"
+DEV_URL="http://localhost:3000"
+RESULTS_DIR="/tmp/pw-baseline-regression"
+RELEASED_JSON="$RESULTS_DIR/baseline-released.json"
+DEV_JSON="$RESULTS_DIR/baseline-dev.json"
+
+mkdir -p "$RESULTS_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Start released container
+# ---------------------------------------------------------------------------
+echo "▶ Starting released plugin container (port 3001)..."
+docker compose -f "$REPO_DIR/docker-compose.released.yml" up -d 2>&1 | grep -v "^$" || true
+
+echo "▶ Waiting for released Grafana to be ready..."
+for i in $(seq 1 30); do
+  if curl -sf "$RELEASED_URL/api/health" 2>/dev/null | grep -q '"database": "ok"'; then
+    echo "  ✓ Ready after ${i}s"
+    break
+  fi
+  sleep 2
+done
+
+# ---------------------------------------------------------------------------
+# 2. Run BASELINE tests against RELEASED plugin
+# ---------------------------------------------------------------------------
+echo ""
+echo "▶ Running BASELINE tests against RELEASED plugin (v2.0.2)..."
+echo "  (${#BASELINE_TESTS[@]} test files — features that existed before our changes)"
+echo ""
+cd "$REPO_DIR"
+GRAFANA_URL="$RELEASED_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=list || true
+GRAFANA_URL="$RELEASED_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=json > "$RELEASED_JSON" 2>/dev/null || true
+echo "  JSON → $RELEASED_JSON"
+
+# ---------------------------------------------------------------------------
+# 3. Run BASELINE tests against DEV build
+# ---------------------------------------------------------------------------
+echo ""
+echo "▶ Running BASELINE tests against DEV build..."
+echo ""
+GRAFANA_URL="$DEV_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=list || true
+GRAFANA_URL="$DEV_URL" npx playwright test "${BASELINE_TESTS[@]}" --reporter=json > "$DEV_JSON" 2>/dev/null || true
+echo "  JSON → $DEV_JSON"
+
+# ---------------------------------------------------------------------------
+# 4. Stop released container
+# ---------------------------------------------------------------------------
+echo ""
+echo "▶ Stopping released container..."
+docker compose -f "$REPO_DIR/docker-compose.released.yml" down 2>&1 | grep -v "^$" || true
+
+# ---------------------------------------------------------------------------
+# 5. Report
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══════════════════════════════════════════════════════════"
+echo " BASELINE REGRESSION REPORT"
+echo " (only tests that existed before our changes)"
+echo "═══════════════════════════════════════════════════════════"
+
+python3 - "$RELEASED_JSON" "$DEV_JSON" <<'PYEOF'
+import json, sys, os
+os.environ["PYTHONUNBUFFERED"] = "1"
+
+def p(*args, **kwargs): print(*args, **kwargs, flush=True)
+
+def collect_specs(suites, prefix=""):
+    for suite in suites:
+        title = suite.get("title", "")
+        full = f"{prefix} › {title}".strip(" › ") if prefix else title
+        for spec in suite.get("specs", []):
+            yield f"{full} › {spec['title']}".strip(" › "), spec.get("ok", False)
+        yield from collect_specs(suite.get("suites", []), full)
+
+def load_results(path):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        p(f"  WARNING: could not load {path}: {e}", file=sys.stderr)
+        return {}
+    return {title: ("passed" if ok else "failed") for title, ok in collect_specs(data.get("suites", []))}
+
+released = load_results(sys.argv[1])
+dev      = load_results(sys.argv[2])
+
+released_pass = sum(1 for s in released.values() if s == "passed")
+dev_pass      = sum(1 for s in dev.values()      if s == "passed")
+
+# Tests that passed on released but fail on dev = genuine regressions we introduced
+regressions = [
+    (t, dev.get(t, "missing"))
+    for t, s in released.items()
+    if s == "passed" and dev.get(t, "missing") != "passed"
+]
+
+# Tests that failed on released but pass on dev = improvements (within baseline scope)
+improvements = [t for t, s in released.items() if s == "failed" and dev.get(t) == "passed"]
+
+p(f"\n  Released v2.0.2 : {released_pass}/{len(released)} baseline tests passed")
+p(f"  Dev build       : {dev_pass}/{len(dev)} baseline tests passed")
+
+if regressions:
+    p(f"\n🔴 TRUE REGRESSIONS ({len(regressions)})")
+    p("   These passed on the released plugin and now fail on dev.\n")
+    for t, status in regressions:
+        p(f"   • [{status}] {t}")
+    p("\n   ↑ These are genuine bugs introduced by our changes.")
+else:
+    p("\n✅ No regressions in baseline tests")
+    p("   Every baseline test that passed on v2.0.2 also passes on dev")
+
+if improvements:
+    p(f"\n🟢 BASELINE IMPROVEMENTS ({len(improvements)})")
+    p("   Baseline tests that failed on released but now pass on dev:\n")
+    for t in improvements:
+        p(f"   • {t}")
+PYEOF

--- a/scripts/baseline-regression-check.sh
+++ b/scripts/baseline-regression-check.sh
@@ -45,6 +45,19 @@ DEV_JSON="$RESULTS_DIR/baseline-dev.json"
 mkdir -p "$RESULTS_DIR"
 
 # ---------------------------------------------------------------------------
+# Detect the released plugin version installed in the released container.
+# Query the running Grafana instance rather than hardcoding a version string.
+# Falls back to "unknown" if the container isn't reachable or the API changes.
+# ---------------------------------------------------------------------------
+detect_released_version() {
+  local version
+  version=$(curl -sf "$RELEASED_URL/api/plugins/briangann-datatable-panel" 2>/dev/null \
+    | python3 -c "import json,sys; print(json.load(sys.stdin).get('info',{}).get('version','unknown'))" 2>/dev/null \
+    || echo "unknown")
+  echo "$version"
+}
+
+# ---------------------------------------------------------------------------
 # 1. Start released container
 # ---------------------------------------------------------------------------
 echo "▶ Starting released plugin container (port 3001)..."
@@ -62,8 +75,11 @@ done
 # ---------------------------------------------------------------------------
 # 2. Run BASELINE tests against RELEASED plugin
 # ---------------------------------------------------------------------------
+RELEASED_VERSION=$(detect_released_version)
+echo "  Released plugin version: ${RELEASED_VERSION}"
+
 echo ""
-echo "▶ Running BASELINE tests against RELEASED plugin (v2.0.2)..."
+echo "▶ Running BASELINE tests against RELEASED plugin (${RELEASED_VERSION})..."
 echo "  (${#BASELINE_TESTS[@]} test files — features that existed before our changes)"
 echo ""
 cd "$REPO_DIR"
@@ -102,7 +118,7 @@ echo " BASELINE REGRESSION REPORT"
 echo " (only tests that existed before our changes)"
 echo "═══════════════════════════════════════════════════════════"
 
-python3 - "$RELEASED_JSON" "$DEV_JSON" <<'PYEOF'
+python3 - "$RELEASED_JSON" "$DEV_JSON" "$RELEASED_VERSION" <<'PYEOF'
 import json, sys, os
 os.environ["PYTHONUNBUFFERED"] = "1"
 
@@ -125,8 +141,9 @@ def load_results(path):
         return {}
     return {title: ("passed" if ok else "failed") for title, ok in collect_specs(data.get("suites", []))}
 
-released = load_results(sys.argv[1])
-dev      = load_results(sys.argv[2])
+released         = load_results(sys.argv[1])
+dev              = load_results(sys.argv[2])
+released_version = sys.argv[3] if len(sys.argv) > 3 else "unknown"
 
 released_pass = sum(1 for s in released.values() if s == "passed")
 dev_pass      = sum(1 for s in dev.values()      if s == "passed")
@@ -141,8 +158,8 @@ regressions = [
 # Tests that failed on released but pass on dev = improvements (within baseline scope)
 improvements = [t for t, s in released.items() if s == "failed" and dev.get(t) == "passed"]
 
-p(f"\n  Released v2.0.2 : {released_pass}/{len(released)} baseline tests passed")
-p(f"  Dev build       : {dev_pass}/{len(dev)} baseline tests passed")
+p(f"\n  Released v{released_version} : {released_pass}/{len(released)} baseline tests passed")
+p(f"  Dev build           : {dev_pass}/{len(dev)} baseline tests passed")
 
 if regressions:
     p(f"\n🔴 TRUE REGRESSIONS ({len(regressions)})")

--- a/scripts/regression-check.sh
+++ b/scripts/regression-check.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# regression-check.sh — run the e2e suite against the released plugin and
+# the local dev build, then report tests that PASSED on released but FAIL on
+# dev (unexpected regressions).
+#
+# Usage: ./scripts/regression-check.sh
+#
+# Prerequisites:
+#   - Docker running
+#   - Local dev container already running on port 3000 (docker compose up)
+#   - pnpm and npx available
+
+set -uo pipefail   # note: no -e so test failures don't abort the script
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+# Use /tmp — NOT inside test-results/ because Playwright cleans that dir at startup
+RESULTS_DIR="/tmp/pw-regression-check"
+
+RELEASED_URL="http://localhost:3001"
+DEV_URL="http://localhost:3000"
+RELEASED_JSON="$RESULTS_DIR/released.json"
+DEV_JSON="$RESULTS_DIR/dev.json"
+
+mkdir -p "$RESULTS_DIR"
+
+# ---------------------------------------------------------------------------
+# 1. Start the released-version container
+# ---------------------------------------------------------------------------
+echo "▶ Starting released plugin container (port 3001)..."
+docker compose -f "$REPO_DIR/docker-compose.released.yml" up -d 2>&1 | grep -v "^$" || true
+
+echo "▶ Waiting for released Grafana to be ready..."
+for i in $(seq 1 30); do
+  if curl -sf "$RELEASED_URL/api/health" 2>/dev/null | grep -q '"database": "ok"'; then
+    echo "  ✓ Ready after ${i}s"
+    break
+  fi
+  sleep 2
+done
+
+# ---------------------------------------------------------------------------
+# 2. Run e2e suite against RELEASED plugin — list reporter for visibility,
+#    json reporter to file for comparison
+# ---------------------------------------------------------------------------
+echo ""
+echo "▶ Running e2e suite against RELEASED plugin (v2.0.2)..."
+echo "  (many failures expected — only regressions matter)"
+echo ""
+cd "$REPO_DIR"
+# First pass: list reporter for real-time progress
+GRAFANA_URL="$RELEASED_URL" npx playwright test --reporter=list || true
+# Second pass: json reporter — stdout → file for diff
+GRAFANA_URL="$RELEASED_URL" npx playwright test --reporter=json > "$RELEASED_JSON" 2>/dev/null || true
+
+echo ""
+echo "  JSON results → $RELEASED_JSON"
+
+# ---------------------------------------------------------------------------
+# 3. Run e2e suite against DEV build
+# ---------------------------------------------------------------------------
+echo ""
+echo "▶ Running e2e suite against DEV build..."
+echo ""
+GRAFANA_URL="$DEV_URL" npx playwright test --reporter=list || true
+mkdir -p "$(dirname "$DEV_JSON")"
+GRAFANA_URL="$DEV_URL" npx playwright test --reporter=json > "$DEV_JSON" 2>/dev/null || true
+
+echo ""
+echo "  JSON results → $DEV_JSON"
+
+# ---------------------------------------------------------------------------
+# 4. Stop the released container
+# ---------------------------------------------------------------------------
+echo ""
+echo "▶ Stopping released container..."
+docker compose -f "$REPO_DIR/docker-compose.released.yml" down 2>&1 | grep -v "^$" || true
+
+# ---------------------------------------------------------------------------
+# 5. Diff: passed on released → failed on dev = regression
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══════════════════════════════════════════════════════════"
+echo " REGRESSION REPORT"
+echo "═══════════════════════════════════════════════════════════"
+
+python3 - "$RELEASED_JSON" "$DEV_JSON" <<'PYEOF'
+import json, sys
+
+def collect_specs(suites, prefix=""):
+    """Recursively walk nested suites, yield (title, ok) for each spec."""
+    for suite in suites:
+        title = suite.get("title", "")
+        full = f"{prefix} › {title}".strip(" › ") if prefix else title
+        for spec in suite.get("specs", []):
+            spec_title = f"{full} › {spec['title']}".strip(" › ")
+            yield spec_title, spec.get("ok", False)
+        yield from collect_specs(suite.get("suites", []), full)
+
+def load_results(path):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"  WARNING: could not load {path}: {e}", file=sys.stderr)
+        return {}
+    results = {}
+    for title, ok in collect_specs(data.get("suites", [])):
+        results[title] = "passed" if ok else "failed"
+    return results
+
+released = load_results(sys.argv[1])
+dev      = load_results(sys.argv[2])
+
+regressions = []
+improvements = []
+new_failures = []
+
+for title, released_status in released.items():
+    dev_status = dev.get(title, "missing")
+    if released_status == "passed" and dev_status in ("failed", "missing"):
+        regressions.append((title, dev_status))
+    elif released_status == "failed" and dev_status == "passed":
+        improvements.append(title)
+
+for title, dev_status in dev.items():
+    if title not in released and dev_status == "failed":
+        new_failures.append(title)
+
+released_pass = sum(1 for s in released.values() if s == "passed")
+dev_pass      = sum(1 for s in dev.values()      if s == "passed")
+
+import os
+os.environ["PYTHONUNBUFFERED"] = "1"
+
+def p(*args, **kwargs):
+    print(*args, **kwargs, flush=True)
+
+p(f"\n  Released v2.0.2 : {released_pass}/{len(released)} passed")
+p(f"  Dev build       : {dev_pass}/{len(dev)} passed")
+
+if regressions:
+    p(f"\n🔴 UNEXPECTED REGRESSIONS ({len(regressions)})")
+    p("   Passed on released → failed/missing on dev:\n")
+    for t, status in regressions:
+        p(f"   • [{status}] {t}")
+else:
+    p("\n✅ No unexpected regressions")
+    p("   Every test that passed on v2.0.2 also passes on dev")
+
+if improvements:
+    p(f"\n🟢 IMPROVEMENTS ({len(improvements)})")
+    p("   Failed on released → now pass on dev:\n")
+    for t in improvements:
+        p(f"   • {t}")
+
+if new_failures:
+    p(f"\n⚪ NEW TESTS FAILING on dev ({len(new_failures)})")
+    p("   Not in released — expected for newly added features:\n")
+    for t in new_failures:
+        p(f"   • {t}")
+PYEOF


### PR DESCRIPTION
## What's in this PR

Two local scripts plus a manually-triggered GitHub Actions workflow for detecting genuine regressions by comparing the e2e test suite against the released plugin (v2.0.2) and the dev build.

---

### GitHub Actions: `.github/workflows/regression-check.yml`

**Manual trigger only** — run when you're ready to verify before merging, not on every commit push.

```bash
gh workflow run regression-check.yml --ref <your-branch>
```
Or use the "Run workflow" button in the GitHub Actions UI. Accepts a `released_version` input (default `v2.0.2`).

**What it does:**
1. Builds the plugin from the branch's code
2. Starts the dev container (current build, port 3000) and released container (v2.0.2, port 3001) **in parallel**
3. Caches the released plugin ZIP so it isn't re-downloaded on every run
4. Runs the 12 baseline test files against both containers
5. Fails if any test that passed on v2.0.2 now fails on dev
6. Uploads results as artifacts

---

### Local scripts

**`scripts/baseline-regression-check.sh`** — Genuine regression check (no noise)

Runs only the 12 test files that existed before PR #329 (the baseline). Any pass→fail is a true regression, not an artifact of tests written for new features. Exits 1 if regressions found.

**`scripts/regression-check.sh`** — Full suite comparison

Runs all 32 tests against both versions. Useful for a total picture including new-feature tests.

---

### Current results (v2.0.2 vs main)

```
Released v2.0.2 : 5/22 baseline tests passed
Dev build       : 22/22 baseline tests passed

✅ No regressions — every baseline test that passed on v2.0.2 also passes on dev
🟢 17 improvements — tests that failed on v2.0.2 now pass
```

---

## Usage

```bash
# Local
docker compose up -d
./scripts/baseline-regression-check.sh   # genuine regression check
./scripts/regression-check.sh            # full suite comparison

# CI (manual trigger)
gh workflow run regression-check.yml --ref feat/my-branch
# Or pass a different released version:
gh workflow run regression-check.yml --ref main \
  --field released_version=v2.0.1
```

## Test plan

- [ ] `./scripts/baseline-regression-check.sh` runs locally with no regressions
- [ ] `gh workflow run regression-check.yml --ref feat/regression-check` triggers successfully
- [ ] Job passes with zero regressions and uploads results artifact